### PR TITLE
Added a clock for linux

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -166,8 +166,10 @@ name = "ptp"
 version = "0.1.0"
 dependencies = [
  "arrayvec",
+ "bitflags",
  "fixed",
  "getset",
+ "libc 0.2.113",
  "nix",
  "num_enum",
  "time",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,3 +12,5 @@ arrayvec = { version = "0.7.2", default-features = false }
 nix = { git = "https://github.com/nix-rust/nix.git", branch = "master" }
 time = "0.3.5"
 getset = "0.1.2"
+libc = { version = "0.2.112", features = ["extra_traits"] }
+bitflags = "1.3.2"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
 pub mod datastructures;
 pub mod network;
 pub mod time;
+pub mod linux_clock;

--- a/src/linux_clock/mod.rs
+++ b/src/linux_clock/mod.rs
@@ -1,0 +1,235 @@
+use self::timex::{StatusFlags, Timex};
+use crate::linux_clock::timex::AdjustFlags;
+use libc::{clockid_t, timespec};
+use std::{fmt::Display, ops::DerefMut};
+
+mod timex;
+
+#[cfg(target_pointer_width = "64")]
+type Fixed = fixed::types::I48F16;
+#[cfg(target_pointer_width = "32")]
+type Fixed = fixed::types::I16F16;
+#[cfg(target_pointer_width = "64")]
+type Int = i64;
+#[cfg(target_pointer_width = "32")]
+type Int = i32;
+
+/// A type for precisely adjusting the time of a linux clock.
+/// Not every clock supports the used API so that's a bit trial and error.
+///
+/// Probably best used with the CLOCK_REALTIME clock.
+/// 
+/// Using the clocks probably requires root access.
+///
+/// # Example
+///
+/// ```no_run
+/// use ptp::linux_clock::LinuxClock;
+/// 
+/// println!("Available clocks:");
+/// for clock in LinuxClock::get_clocks() {
+///     println!("{}", clock);
+/// }
+///
+/// let mut test_clock = LinuxClock::get_realtime_clock();
+/// test_clock.adjust_clock(0.000_001, 1.000_000_001).unwrap();
+/// ```
+#[derive(Debug, Clone)]
+pub struct LinuxClock {
+    id: clockid_t,
+    name: String,
+}
+impl LinuxClock {
+    /// https://manpages.debian.org/testing/manpages-dev/ntp_adjtime.3.en.html#DESCRIPTION
+    fn get_clock_state(&self) -> Result<(Timex, ClockState), i32> {
+        let mut value = Timex::new();
+        match unsafe { libc::clock_adjtime(self.id, value.deref_mut() as *mut _) } {
+            libc::TIME_OK => Ok((value, ClockState::OK)),
+            libc::TIME_INS => Ok((value, ClockState::INS)),
+            libc::TIME_DEL => Ok((value, ClockState::DEL)),
+            libc::TIME_OOP => Ok((value, ClockState::OOP)),
+            libc::TIME_WAIT => Ok((value, ClockState::WAIT)),
+            libc::TIME_ERROR => Ok((value, ClockState::ERROR)),
+            -1 => {
+                let errno = unsafe { *libc::__errno_location() };
+                Err(errno)
+            }
+            _ => unreachable!(),
+        }
+    }
+
+    /// Adjusts the clock
+    /// 
+    /// - The time_offset is given in seconds.
+    /// - The frequency_multiplier is the value that the *current* frequency should be multiplied with to get to the target frequency.
+    /// 
+    /// For example, if the clock is at 10.0 mhz, but should run at 10.1 mhz, then the frequency_multiplier should be 1.01.
+    /// 
+    /// If the time offset is higher than 0.5 seconds, then the clock will be set directly and no frequency change will be made.
+    pub fn adjust_clock(&mut self, time_offset: f64, frequency_multiplier: f64) -> Result<(), i32> {
+        let (current_timex, _clock_state) = self.get_clock_state()?;
+
+        if time_offset.abs() > 0.5 {
+            // The time offset is more than we can change with precision, so we're just going to set the current time
+
+            let current_nanos = if current_timex.get_status().contains(StatusFlags::NANO) {
+                current_timex.time.tv_usec
+            } else {
+                current_timex.time.tv_usec * 1000
+            };
+
+            // We need to be careful. The nanos may only be 1_000_000_000 at the most
+            let new_nanos = current_nanos + (time_offset.fract() * 1_000_000_000.0) as Int;
+            let new_seconds =
+                current_timex.time.tv_sec + time_offset.floor() as Int + new_nanos / 1_000_000_000;
+
+            let new_time = libc::timespec {
+                tv_sec: new_seconds,
+                tv_nsec: new_nanos % 1_000_000_000,
+            };
+
+            // Set the clock time using the 'normal' clock api
+            let error = unsafe { libc::clock_settime(self.id, &new_time as *const _) };
+            match error {
+                -1 => Err(unsafe { *libc::__errno_location() }),
+                _ => Ok(()),
+            }
+        } else {
+            // We do an offset with precision
+            let mut new_timex = current_timex.clone();
+
+            new_timex.set_status(
+                StatusFlags::PLL // We want to change the PLL, a major component in the clock circuit
+                    | StatusFlags::PPSFREQ // We want the PPS signal to change as well
+                    | StatusFlags::PPSTIME // The PPS time should be changed
+                    | StatusFlags::FREQHOLD, // We want no automatic frequency updates
+            );
+
+            new_timex.set_mode(
+                AdjustFlags::SETOFFSET // We have an offset to set
+                | AdjustFlags::FREQUENCY // We'll be setting the frequency as well
+                | AdjustFlags::NANO // We're using nanoseconds
+            );
+
+            // Start with a seconds value of 0 and express the full time offset in nanos
+            new_timex.time.tv_sec = 0;
+            new_timex.time.tv_usec = (time_offset * 1_000_000_000.0) as Int;
+
+            // The nanos must not be negative. In that case the timestamp must be delivered as a negative seconds with a postive nanos value
+            while new_timex.time.tv_usec < 0 {
+                new_timex.time.tv_sec -= 1;
+                new_timex.time.tv_usec += 1_000_000_000;
+            }
+
+            // We need to change the ppm value to a speed factor so we can use multiplication to get the new frequency
+            let current_ppm = current_timex.get_frequency();
+            // The ppm is an offset from the main frequency, so it's the base +- the ppm expressed as a percentage.
+            // Ppm is in the opposite direction from the speed factor. A postive ppm means the clock is running slower, so we use its negative.
+            let current_frequency_multiplier = 1.0 + -current_ppm.to_num::<f64>() / 1_000_000.0;
+            // Now multiply the frequencies
+            let new_frequency_multiplier = current_frequency_multiplier * frequency_multiplier;
+            // Get back the new ppm value by subtracting the 1.0 base from it, changing the percentage to the ppm again and then taking the negative of that.
+            let new_ppm = -Fixed::from_num((new_frequency_multiplier - 1.0) * 1_000_000.0);
+
+            new_timex.set_frequency(new_ppm);
+
+            // Adjust the clock time and handle its errors
+            let error = unsafe { libc::clock_adjtime(self.id, new_timex.deref_mut() as *mut _) };
+            match error {
+                -1 => Err(unsafe { *libc::__errno_location() }),
+                _ => Ok(()),
+            }
+        }
+    }
+
+    pub fn get_clocks() -> impl Iterator<Item = Self> {
+        const CLOCKS: [(clockid_t, &str); 11] = [
+            (libc::CLOCK_BOOTTIME, "CLOCK_BOOTTIME"),
+            (libc::CLOCK_BOOTTIME_ALARM, "CLOCK_BOOTTIME_ALARM"),
+            (libc::CLOCK_MONOTONIC, "CLOCK_MONOTONIC"),
+            (libc::CLOCK_MONOTONIC_COARSE, "CLOCK_MONOTONIC_COARSE"),
+            (libc::CLOCK_MONOTONIC_RAW, "CLOCK_MONOTONIC_RAW"),
+            (libc::CLOCK_PROCESS_CPUTIME_ID, "CLOCK_PROCESS_CPUTIME_ID"),
+            (libc::CLOCK_REALTIME, "CLOCK_REALTIME"),
+            (libc::CLOCK_REALTIME_ALARM, "CLOCK_REALTIME_ALARM"),
+            (libc::CLOCK_REALTIME_COARSE, "CLOCK_REALTIME_COARSE"),
+            (libc::CLOCK_TAI, "CLOCK_TAI"),
+            (libc::CLOCK_THREAD_CPUTIME_ID, "CLOCK_THREAD_CPUTIME_ID"),
+        ];
+
+        CLOCKS.into_iter().map(|(id, name)| Self {
+            id,
+            name: name.into(),
+        })
+    }
+
+    pub fn get_realtime_clock() -> Self {
+        Self::get_clocks().find(|c| c.id == libc::CLOCK_REALTIME).unwrap()
+    }
+}
+
+impl Display for LinuxClock {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        const SECS_IN_DAY: Int = 24 * 60 * 60;
+
+        let mut time = Some(timespec {
+            tv_sec: 0,
+            tv_nsec: 0,
+        });
+        if unsafe { libc::clock_gettime(self.id, time.as_mut().unwrap_unchecked() as *mut _) } == -1
+        {
+            time = None;
+        }
+
+        let mut resolution = Some(timespec {
+            tv_sec: 0,
+            tv_nsec: 0,
+        });
+        if unsafe { libc::clock_getres(self.id, resolution.as_mut().unwrap_unchecked() as *mut _) }
+            == -1
+        {
+            resolution = None;
+        }
+
+        write!(f, "{:<15}: ", self.name)?;
+        match time {
+            Some(time) => {
+                write!(f, "{:10}.{:03} (", time.tv_sec, time.tv_nsec / 1000000)?;
+                let days = time.tv_sec / SECS_IN_DAY;
+                if days > 0 {
+                    write!(f, "{} days + ", days)?;
+                }
+                writeln!(
+                    f,
+                    "{:2}h {:2}m {:2}s)",
+                    (time.tv_sec % SECS_IN_DAY) / 3600,
+                    (time.tv_sec % 3600) / 60,
+                    time.tv_sec % 60
+                )?;
+            }
+            None => writeln!(f, "TIME ERROR")?,
+        }
+
+        match resolution {
+            Some(resolution) => writeln!(
+                f,
+                "     resolution: {:10}.{:09}",
+                resolution.tv_sec, resolution.tv_nsec
+            )?,
+            None => writeln!(f, "     resolution: RESOLUTION ERROR",)?,
+        }
+
+        Ok(())
+    }
+}
+
+/// Reflects: https://manpages.debian.org/testing/manpages-dev/ntp_adjtime.3.en.html#RETURN_VALUE
+#[derive(Debug, Clone)]
+pub enum ClockState {
+    OK,
+    INS,
+    DEL,
+    OOP,
+    WAIT,
+    ERROR,
+}

--- a/src/linux_clock/timex.rs
+++ b/src/linux_clock/timex.rs
@@ -1,0 +1,192 @@
+use bitflags::bitflags;
+use libc::timex;
+use std::ops::{Deref, DerefMut};
+
+use super::Fixed;
+
+#[derive(Clone)]
+pub struct Timex(timex);
+
+#[allow(dead_code)]
+impl Timex {
+    pub fn new() -> Self {
+        Self(new_timex())
+    }
+
+    pub fn get_status(&self) -> StatusFlags {
+        StatusFlags::from_bits_truncate(self.status)
+    }
+
+    pub fn set_status(&mut self, value: StatusFlags) {
+        self.status = value.bits();
+    }
+
+    pub fn get_mode(&self) -> AdjustFlags {
+        AdjustFlags::from_bits_truncate(self.modes)
+    }
+
+    pub fn set_mode(&mut self, value: AdjustFlags) {
+        self.modes = value.bits();
+    }
+
+    /// The frequency offset in PPM
+    pub fn get_frequency(&self) -> Fixed {
+        Fixed::from_bits(self.freq)
+    }
+
+    /// The frequency offset in PPM
+    pub fn set_frequency(&mut self, value: Fixed) {
+        self.freq = value.to_bits().clamp(-32768000, 32768000);
+    }
+
+    /// The pps frequency offset in PPM
+    pub fn get_pps_frequency(&self) -> Fixed {
+        Fixed::from_bits(self.ppsfreq)
+    }
+
+    /// The stabil frequency offset in PPM
+    pub fn get_stabil_frequency(&self) -> Fixed {
+        Fixed::from_bits(self.stabil)
+    }
+}
+
+impl Deref for Timex {
+    type Target = timex;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl DerefMut for Timex {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
+
+// https://manpages.debian.org/testing/manpages-dev/ntp_adjtime.3.en.html#DESCRIPTION
+bitflags! {
+    pub struct StatusFlags: i32 {
+        /// Enable phase-locked loop (PLL) updates via ADJ_OFFSET.
+        const PLL = libc::STA_PLL;
+        /// Enable PPS (pulse-per-second) frequency discipline.
+        const PPSFREQ = libc::STA_PPSFREQ;
+        /// Enable PPS time discipline.
+        const PPSTIME = libc::STA_PPSTIME;
+        /// Select frequency-locked loop (FLL) mode.
+        const FLL = libc::STA_FLL;
+        /// Insert a leap second after the last second of the UTC day, thus extending the last minute of the day by one second.
+        /// Leap-second insertion will occur each day, so long as this flag remains set.
+        const INS = libc::STA_INS;
+        /// Delete a leap second at the last second of the UTC day.
+        /// Leap second deletion will occur each day, so long as this flag remains set.
+        const DEL = libc::STA_DEL;
+        /// Clock unsynchronized.
+        const UNSYNC = libc::STA_UNSYNC;
+        /// Hold frequency. Normally adjustments made via ADJ_OFFSET result in dampened frequency adjustments also being made.
+        /// So a single call corrects the current offset, but as offsets in the same direction are made repeatedly, the small frequency adjustments will accumulate to fix the long-term skew.
+        /// 
+        /// This flag prevents the small frequency adjustment from being made when correcting for an ADJ_OFFSET value.
+        const FREQHOLD = libc::STA_FREQHOLD;
+        /// A valid PPS (pulse-per-second) signal is present.
+        const PPSSIGNAL = libc::STA_PPSSIGNAL;
+        /// PPS signal jitter exceeded.
+        const PPSJITTER = libc::STA_PPSJITTER;
+        /// PPS signal wander exceeded.
+        const PPSWANDER = libc::STA_PPSWANDER;
+        /// PPS signal calibration error.
+        const PPSERROR = libc::STA_PPSERROR;
+        /// Clock hardware fault.
+        const CLOCKERR = libc::STA_CLOCKERR;
+        /// Resolution (0 = microsecond, 1 = nanoseconds). Set via ADJ_NANO, cleared via ADJ_MICRO.
+        const NANO = libc::STA_NANO;
+        /// Mode (0 = Phase Locked Loop, 1 = Frequency Locked Loop).
+        const MODE = libc::STA_MODE;
+        /// Clock source (0 = A, 1 = B); currently unused.
+        const CLK = libc::STA_CLK;
+    }
+
+    pub struct AdjustFlags: u32 {
+        /// Set time offset from buf.offset. Since Linux 2.6.26, the supplied value is clamped to the range (-0.5s, +0.5s).
+        /// In older kernels, an EINVAL error occurs if the supplied value is out of range.
+        const OFFSET = libc::ADJ_OFFSET;
+        /// Set frequency offset from buf.freq. Since Linux 2.6.26, the supplied value is clamped to the range (-32768000, +32768000).
+        /// In older kernels, an EINVAL error occurs if the supplied value is out of range.
+        const FREQUENCY = libc::ADJ_FREQUENCY;
+        /// Set maximum time error from buf.maxerror.
+        const MAXERROR = libc::ADJ_MAXERROR;
+        /// Set estimated time error from buf.esterror.
+        const ESTERROR = libc::ADJ_ESTERROR;
+        /// Set clock status bits from buf.status.
+        const STATUS = libc::ADJ_STATUS;
+        /// Set PLL time constant from buf.constant. If the STA_NANO status flag is clear, the kernel adds 4 to this value.
+        const TIMECONST = libc::ADJ_TIMECONST;
+        /// Add buf.time to the current time. If buf.status includes the ADJ_NANO flag, then buf.time.tv_usec is interpreted as a nanosecond value;
+        /// otherwise it is interpreted as microseconds.
+        /// 
+        /// The value of buf.time is the sum of its two fields, but the field buf.time.tv_usec must always be nonnegative.
+        /// The following example shows how to normalize a timeval with nanosecond resolution.
+        /// 
+        /// ```C
+        /// while (buf.time.tv_usec < 0) {
+        ///     buf.time.tv_sec  -= 1;
+        ///     buf.time.tv_usec += 1000000000;
+        /// }
+        /// ```   
+        const SETOFFSET = libc::ADJ_SETOFFSET;
+        /// Select microsecond resolution.
+        const MICRO = libc::ADJ_MICRO;
+        /// Select nanosecond resolution. Only one of ADJ_MICRO and ADJ_NANO should be specified.
+        const NANO = libc::ADJ_NANO;
+        /// Set TAI (Atomic International Time) offset from buf.constant.
+        ///
+        /// ADJ_TAI should not be used in conjunction with ADJ_TIMECONST, since the latter mode also employs the buf.constant field.
+        /// For a complete explanation of TAI and the difference between TAI and UTC, see [BIPM](http://www.bipm.org/en/bipm/tai/tai.html) 
+        const TAI = libc::ADJ_TAI;
+        /// Set tick value from buf.tick.
+        const TICK = libc::ADJ_TICK;
+        /// Old-fashioned adjtime(3): (gradually) adjust time by value specified in buf.offset, which specifies an adjustment in microseconds.
+        const OFFSET_SINGLESHOT = libc::ADJ_OFFSET_SINGLESHOT;
+        /// Return (in buf.offset) the remaining amount of time to be adjusted after an earlier ADJ_OFFSET_SINGLESHOT operation.
+        /// This feature was added in Linux 2.6.24, but did not work correctly until Linux 2.6.28.
+        const OFFSET_SS_READ = libc::ADJ_OFFSET_SS_READ;
+    }
+}
+fn new_timex() -> timex {
+    timex {
+        modes: 0,
+        offset: 0,
+        freq: 0,
+        maxerror: 0,
+        esterror: 0,
+        status: 0,
+        constant: 0,
+        precision: 0,
+        tolerance: 0,
+        time: libc::timeval {
+            tv_sec: 0,
+            tv_usec: 0,
+        },
+        tick: 0,
+        ppsfreq: 0,
+        jitter: 0,
+        shift: 0,
+        stabil: 0,
+        jitcnt: 0,
+        calcnt: 0,
+        errcnt: 0,
+        stbcnt: 0,
+        tai: 0,
+        __unused1: 0,
+        __unused2: 0,
+        __unused3: 0,
+        __unused4: 0,
+        __unused5: 0,
+        __unused6: 0,
+        __unused7: 0,
+        __unused8: 0,
+        __unused9: 0,
+        __unused10: 0,
+        __unused11: 0,
+    }
+}


### PR DESCRIPTION
Tested on the RPI and the PPS changed using the REALTIME clock.

In case there's doubt, let me pre-explain:
- Using a seconds parameter and frequency multiplier parameter was by far the best API surface since it maps nicely to the workings of most clocks. The frequency multiplier is also the data you'll be left with with the syntonization process.
- Using f64 works very nicely here. These are only offset values and will become more precise, the more precise you need them to be (close to synchronization). When your offset is big, you will never be precise anyways and with f64 you can make (almost) arbitrarily sized offsets.