### PR TITLE
use libc ifreq

### DIFF
--- a/statime-linux/src/network/linux_syscall.rs
+++ b/statime-linux/src/network/linux_syscall.rs
@@ -1,47 +1,6 @@
-use std::{ffi::CString, intrinsics::transmute};
+use std::ffi::CString;
 
 use nix::ioctl_readwrite_bad;
-
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub struct Ifmap {
-    pub mem_start: libc::c_ulong,
-    pub mem_end: libc::c_ulong,
-    pub base_addr: libc::c_ushort,
-    pub irq: libc::c_char,
-    pub dma: libc::c_char,
-    pub port: libc::c_char,
-}
-
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub union IfrIfrn {
-    pub ifrn_name: [libc::c_char; libc::IFNAMSIZ],
-}
-
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub union IfrIfru {
-    pub ifru_addr: libc::sockaddr,
-    pub ifru_dstaddr: libc::sockaddr,
-    pub ifru_broadaddr: libc::sockaddr,
-    pub ifru_netmask: libc::sockaddr,
-    pub ifru_hwaddr: libc::sockaddr,
-    pub ifru_flags: libc::c_short,
-    pub ifru_ivalue: libc::c_int,
-    pub ifru_mtu: libc::c_int,
-    pub ifru_map: Ifmap,
-    pub ifru_slave: [libc::c_char; libc::IFNAMSIZ],
-    pub ifru_newname: [libc::c_char; libc::IFNAMSIZ],
-    pub ifru_data: *mut libc::c_char,
-}
-
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub struct Ifreq {
-    pub ifr_ifrn: IfrIfrn,
-    pub ifr_ifru: IfrIfru,
-}
 
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -56,7 +15,7 @@ const HWTSTAMP_FILTER_ALL: libc::c_int = 1;
 
 const SIOCSHWTSTAMP: u16 = 0x89b0;
 
-ioctl_readwrite_bad!(siocshwtstamp, SIOCSHWTSTAMP, Ifreq);
+ioctl_readwrite_bad!(siocshwtstamp, SIOCSHWTSTAMP, libc::ifreq);
 
 pub fn driver_enable_hardware_timestamping(socket: i32, interface: &str) {
     let mut tstamp_config = HwtstampConfig {
@@ -65,27 +24,20 @@ pub fn driver_enable_hardware_timestamping(socket: i32, interface: &str) {
         rx_filter: HWTSTAMP_FILTER_ALL,
     };
 
-    let mut ifreq = Ifreq {
-        ifr_ifrn: IfrIfrn {
-            ifrn_name: [0; libc::IFNAMSIZ],
-        },
-        ifr_ifru: IfrIfru {
-            ifru_data: unsafe { transmute(&mut tstamp_config as *mut _) },
-        },
-    };
-
     let ifname = CString::new(interface).expect("Cannot convert interface name to C string");
     if ifname.as_bytes_with_nul().len() > libc::IFNAMSIZ {
         panic!("Interface name too long");
     }
 
-    for (from, to) in ifname
-        .as_bytes_with_nul()
-        .iter()
-        .zip(unsafe { ifreq.ifr_ifrn.ifrn_name.iter_mut() })
-    {
-        *to = *from as _;
-    }
+    let mut it = ifname.as_bytes_with_nul().iter();
+    let ifr_name = std::array::from_fn(|_| it.next().copied().unwrap_or_default() as i8);
+
+    let mut ifreq = libc::ifreq {
+        ifr_name,
+        ifr_ifru: libc::__c_anonymous_ifr_ifru {
+            ifru_data: (&mut tstamp_config as *mut _) as *mut libc::c_char,
+        },
+    };
 
     unsafe { siocshwtstamp(socket, &mut ifreq as *mut _) }
         .expect("Failed to enable hardware timestamping in the driver");


### PR DESCRIPTION
`ifreq` was upstreamed from ntpd-rs into libc. We can now use it here too