### PR TITLE
refactoring to make linux easier to test (e.g. simulate)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -115,9 +115,9 @@ checksum = "c041d3eab048880cb0b86b256447da3f18859a163c3b8d8893f4e6368abe6393"
 
 [[package]]
 name = "bytes"
-version = "1.3.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfb24e866b15a1af2a1b663f10c6b6b8f397a84aadb828f12e5b289ec23a3a3c"
+checksum = "89b2fd2a0dcf38d7971e2194b6b6eebab45ae01067456a7fd93d5547a61b70be"
 
 [[package]]
 name = "cc"
@@ -554,14 +554,14 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5d732bc30207a6423068df043e3d02e0735b155ad7ce1a6f76fe2baa5b158de"
+checksum = "5b9d9a46eff5b4ff64b45a9e316a6d1e0bc719ef429cbec4dc630684212bfdf9"
 dependencies = [
  "libc",
  "log",
  "wasi 0.11.0+wasi-snapshot-preview1",
- "windows-sys 0.42.0",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -631,15 +631,15 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.9.6"
+version = "0.9.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba1ef8814b5c993410bb3adfad7a5ed269563e4a2f90c41f5d85be7fb47133bf"
+checksum = "9069cbb9f99e3a5083476ccb29ceb1de18b9118cafa53e90c9551235de2b9521"
 dependencies = [
  "cfg-if",
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-sys 0.42.0",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -753,9 +753,9 @@ checksum = "ddccb15bcce173023b3fedd9436f882a0739b8dfb45e4f6b6002bee5929f61b2"
 
 [[package]]
 name = "signal-hook-registry"
-version = "1.4.0"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e51e73328dc4ac0c7ccbda3a494dfa03df1de2f46018127f60c693f2648455b0"
+checksum = "d8229b473baa5980ac72ef434c4415e70c4b5e71b423043adb4ba059f89c99a1"
 dependencies = [
  "libc",
 ]
@@ -1037,17 +1037,11 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-sys"
-version = "0.42.0"
+version = "0.45.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a3e1820f08b8513f676f7ab6c1f99ff312fb97b553d30ff4dd86f9f15728aa7"
+checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
 dependencies = [
- "windows_aarch64_gnullvm 0.42.2",
- "windows_aarch64_msvc 0.42.2",
- "windows_i686_gnu 0.42.2",
- "windows_i686_msvc 0.42.2",
- "windows_x86_64_gnu 0.42.2",
- "windows_x86_64_gnullvm 0.42.2",
- "windows_x86_64_msvc 0.42.2",
+ "windows-targets 0.42.2",
 ]
 
 [[package]]
@@ -1056,7 +1050,22 @@ version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.48.0",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
+dependencies = [
+ "windows_aarch64_gnullvm 0.42.2",
+ "windows_aarch64_msvc 0.42.2",
+ "windows_i686_gnu 0.42.2",
+ "windows_i686_msvc 0.42.2",
+ "windows_x86_64_gnu 0.42.2",
+ "windows_x86_64_gnullvm 0.42.2",
+ "windows_x86_64_msvc 0.42.2",
 ]
 
 [[package]]

--- a/statime-linux/src/main.rs
+++ b/statime-linux/src/main.rs
@@ -177,96 +177,6 @@ async fn main() {
     instance.run(&LinuxTimer).await;
 }
 
-#[cfg(test)]
-mod tests {
-    use std::str::FromStr;
-
-    use statime_linux::network::{InterfaceName, LinuxNetworkMode};
-
-    use super::*;
-
-    #[tokio::test]
-    async fn two_ordinary_clocks() {
-        setup_logger(log::LevelFilter::Trace).unwrap();
-
-        // let interface_name_1 = InterfaceName::from_str("enp0s31f6").unwrap();
-        let interface_name_1 = InterfaceName::from_str("br-44f18fce9cc6").unwrap();
-        // let interface_name_2 = InterfaceName::from_str("virbr0").unwrap();
-        let interface_name_2 = InterfaceName::from_str("br-2f64ef4c8839").unwrap();
-
-        let interface_1 = InterfaceDescriptor {
-            interface_name: Some(interface_name_1),
-            mode: LinuxNetworkMode::Ipv4,
-        };
-
-        let interface_2 = InterfaceDescriptor {
-            interface_name: Some(interface_name_2),
-            mode: LinuxNetworkMode::Ipv4,
-        };
-
-        let default_ds_config_high = DefaultDSConfig {
-            priority_1: 128,
-            priority_2: 128,
-            sdo: SdoId::default(),
-            domain: 0,
-            slave_only: false,
-        };
-
-        let default_ds_config_low = DefaultDSConfig {
-            priority_1: 1,
-            priority_2: 1,
-            sdo: SdoId::default(),
-            domain: 0,
-            slave_only: false,
-        };
-
-        let port_ds_config = PortDSConfig {
-            log_announce_interval: 1,
-            log_sync_interval: 0,
-            announce_receipt_timeout: 3,
-        };
-
-        let mut ordinary1 = build_instance(
-            interface_1,
-            TimestampingMode::Software,
-            LinuxClock::new(RawLinuxClock::get_realtime_clock()),
-            ClockIdentity(42u64.to_be_bytes()),
-            default_ds_config_low,
-            port_ds_config,
-            Ports {
-                tc_port: 8007,
-                ntc_port: 8008,
-            },
-        );
-
-        let mut ordinary2 = build_instance(
-            interface_2,
-            TimestampingMode::Software,
-            LinuxClock::new(RawLinuxClock::get_realtime_clock()),
-            ClockIdentity(43u64.to_be_bytes()),
-            default_ds_config_high,
-            port_ds_config,
-            Ports {
-                tc_port: 8007 + 2,
-                ntc_port: 8008 + 2,
-            },
-        );
-
-        let handle1 = async {
-            ordinary1.run(&LinuxTimer).await;
-        };
-
-        let handle2 = async {
-            ordinary2.run(&LinuxTimer).await;
-        };
-
-        tokio::select! {
-            err = handle1 => panic!("{err:?}"),
-            // err = handle2 => panic!("{err:?}"),
-        }
-    }
-}
-
 fn build_instance(
     interface: InterfaceDescriptor,
     timestamping_mode: TimestampingMode,
@@ -312,4 +222,84 @@ fn build_instance(
         local_clock,
         BasicFilter::new(0.25),
     )
+}
+
+#[cfg(test)]
+mod tests {
+    use std::str::FromStr;
+
+    use statime_linux::network::{InterfaceName, LinuxNetworkMode};
+
+    use super::*;
+
+    #[tokio::test]
+    async fn two_ordinary_clocks() {
+        setup_logger(log::LevelFilter::Info).unwrap();
+
+        let ports = Ports {
+            tc_port: 8007,
+            ntc_port: 8008,
+        };
+
+        let interface_name = InterfaceName::from_str("br-44f18fce9cc6").unwrap();
+        let interface = InterfaceDescriptor {
+            interface_name: Some(interface_name),
+            mode: LinuxNetworkMode::Ipv4,
+        };
+
+        let default_ds_config_high = DefaultDSConfig {
+            priority_1: 128,
+            priority_2: 128,
+            sdo: SdoId::default(),
+            domain: 0,
+            slave_only: false,
+        };
+
+        let default_ds_config_low = DefaultDSConfig {
+            priority_1: 1,
+            priority_2: 1,
+            sdo: SdoId::default(),
+            domain: 0,
+            slave_only: false,
+        };
+
+        let port_ds_config = PortDSConfig {
+            log_announce_interval: 1,
+            log_sync_interval: 0,
+            announce_receipt_timeout: 3,
+        };
+
+        let mut ordinary1 = build_instance(
+            interface,
+            TimestampingMode::Software,
+            LinuxClock::new(RawLinuxClock::get_realtime_clock()),
+            ClockIdentity(42u64.to_be_bytes()),
+            default_ds_config_low,
+            port_ds_config,
+            ports,
+        );
+
+        let mut ordinary2 = build_instance(
+            interface,
+            TimestampingMode::Software,
+            LinuxClock::new(RawLinuxClock::get_realtime_clock()),
+            ClockIdentity(43u64.to_be_bytes()),
+            default_ds_config_high,
+            port_ds_config,
+            ports,
+        );
+
+        let handle1 = async {
+            ordinary1.run(&LinuxTimer).await;
+        };
+
+        let handle2 = async {
+            ordinary2.run(&LinuxTimer).await;
+        };
+
+        tokio::select! {
+            err = handle1 => panic!("{err:?}"),
+            err = handle2 => panic!("{err:?}"),
+        }
+    }
 }

--- a/statime-linux/src/network/interface.rs
+++ b/statime-linux/src/network/interface.rs
@@ -94,7 +94,6 @@ pub struct InterfaceName {
 }
 
 impl InterfaceName {
-    #[cfg(test)]
     pub const LOOPBACK: Self = Self {
         bytes: *b"lo\0\0\0\0\0\0\0\0\0\0\0\0\0\0",
     };
@@ -170,7 +169,7 @@ impl std::str::FromStr for InterfaceName {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Copy)]
 pub struct InterfaceDescriptor {
     pub interface_name: Option<InterfaceName>,
     pub mode: LinuxNetworkMode,

--- a/statime-linux/src/network/mod.rs
+++ b/statime-linux/src/network/mod.rs
@@ -4,6 +4,8 @@ pub mod linux;
 mod raw_udp_socket;
 mod timestamped_udp_socket;
 
+pub use interface::{InterfaceName, LinuxNetworkMode};
+
 /// Turn a C failure (-1 is returned) into a rust Result
 pub(crate) fn cerr(t: libc::c_int) -> std::io::Result<libc::c_int> {
     match t {

--- a/statime-linux/src/network/timestamped_udp_socket.rs
+++ b/statime-linux/src/network/timestamped_udp_socket.rs
@@ -16,6 +16,16 @@ pub struct TimestampedUdpSocket {
     send_counter: u32,
 }
 
+impl Clone for TimestampedUdpSocket {
+    fn clone(&self) -> Self {
+        Self {
+            io: AsyncFd::new(self.io.get_ref().try_clone().unwrap()).unwrap(),
+            exceptional_condition: exceptional_condition_fd(self.io.get_ref()).unwrap(),
+            send_counter: self.send_counter.clone(),
+        }
+    }
+}
+
 impl TimestampedUdpSocket {
     pub fn from_udp_socket(
         io: std::net::UdpSocket,
@@ -67,8 +77,7 @@ impl TimestampedUdpSocket {
         if let Ok(send_timestamp) = tokio::time::timeout(timeout, fetch).await {
             Ok(Some(send_timestamp?))
         } else {
-            log::warn!("Packet without timestamp (waiting for timestamp timed out)");
-            eprintln!("Packet without timestamp (waiting for timestamp timed out)");
+            log::warn!("Packet without send timestamp (waiting for timestamp timed out)");
             Ok(None)
         }
     }

--- a/statime/src/bmc/bmca.rs
+++ b/statime/src/bmc/bmca.rs
@@ -23,6 +23,7 @@ use crate::{
 /// - When it is time to run the algorithm, the ptp runtime has to take all the best announce messages using [Bmca::take_best_port_announce_message]
 /// - Of the resulting set, the best global one needs to be determined. This can be done using [Bmca::find_best_announce_message]
 /// - Then to get the recommended state for each port, [Bmca::calculate_recommended_state] needs to be called
+#[derive(Clone)]
 pub struct Bmca {
     foreign_master_list: ForeignMasterList,
     own_port_identity: PortIdentity,

--- a/statime/src/bmc/foreign_master.rs
+++ b/statime/src/bmc/foreign_master.rs
@@ -24,6 +24,7 @@ const MAX_ANNOUNCE_MESSAGES: usize = 8;
 /// The maximum amount of foreign masters to store at the same time
 const MAX_FOREIGN_MASTERS: usize = 8;
 
+#[derive(Clone)]
 pub struct ForeignMaster {
     foreign_master_port_identity: PortIdentity,
     // Must have a capacity of at least 2
@@ -80,6 +81,7 @@ impl ForeignMaster {
     }
 }
 
+#[derive(Clone)]
 pub struct ForeignMasterList {
     // Must have a capacity of at least 5
     foreign_masters: ArrayVec<ForeignMaster, MAX_FOREIGN_MASTERS>,
@@ -125,6 +127,8 @@ impl ForeignMasterList {
                 continue;
             }
         }
+
+        log::warn!("qualified_foreign_masters {:?}", &qualified_foreign_masters);
 
         qualified_foreign_masters.into_iter()
     }

--- a/statime/src/datastructures/datasets/port.rs
+++ b/statime/src/datastructures/datasets/port.rs
@@ -10,7 +10,7 @@ use crate::{
     time::Duration,
 };
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct PortDS {
     pub(crate) port_identity: PortIdentity,
     pub(crate) port_state: PortState,
@@ -107,7 +107,7 @@ impl PortDS {
 
     pub fn set_forced_port_state(&mut self, state: PortState) {
         log::info!(
-            "new state for port {}: {} -> {}",
+            "new state for PTP port {}: {} -> {}",
             self.port_identity.port_number,
             self.port_state,
             state

--- a/statime/src/port/mod.rs
+++ b/statime/src/port/mod.rs
@@ -36,7 +36,17 @@ pub struct Port<P> {
 }
 
 impl<P> Port<P> {
-    pub async fn new<NR>(
+    pub fn new(port_ds: PortDS, network_port: P) -> Self {
+        let bmca = Bmca::new(port_ds.announce_interval().into(), port_ds.port_identity);
+
+        Port {
+            port_ds,
+            network_port,
+            bmca,
+        }
+    }
+
+    pub async fn init<NR>(
         port_ds: PortDS,
         runtime: &mut NR,
         interface: NR::InterfaceDescriptor,
@@ -49,13 +59,7 @@ impl<P> Port<P> {
             .await
             .expect("Could not create network port");
 
-        let bmca = Bmca::new(port_ds.announce_interval().into(), port_ds.port_identity);
-
-        Port {
-            port_ds,
-            network_port,
-            bmca,
-        }
+        Self::new(port_ds, network_port)
     }
 
     pub fn identity(&self) -> PortIdentity {

--- a/statime/src/port/mod.rs
+++ b/statime/src/port/mod.rs
@@ -29,6 +29,7 @@ pub mod state;
 mod tests;
 mod ticker;
 
+#[derive(Clone)]
 pub struct Port<P> {
     port_ds: PortDS,
     network_port: P,
@@ -261,6 +262,7 @@ impl<P: NetworkPort> Port<P> {
         if message.header().sdo_id() != default_ds.sdo_id
             || message.header().domain_number() != default_ds.domain_number
         {
+            log::trace!("Ignored message from self {:?}", &message);
             return Ok(());
         }
 

--- a/statime/src/port/state/master.rs
+++ b/statime/src/port/state/master.rs
@@ -151,6 +151,7 @@ impl MasterState {
                 _ => Err(MasterError::UnexpectedMessage.into()),
             }
         } else {
+            log::trace!("Ignored message from self {:?}", &message);
             Ok(())
         }
     }

--- a/statime/src/port/state/master.rs
+++ b/statime/src/port/state/master.rs
@@ -148,10 +148,13 @@ impl MasterState {
                     )
                     .await
                 }
-                _ => Err(MasterError::UnexpectedMessage.into()),
+                _ => {
+                    log::error!("A Master can never process {:?}", &message);
+                    Err(MasterError::UnexpectedMessage.into())
+                }
             }
         } else {
-            log::trace!("Ignored message from self {:?}", &message);
+            // log::trace!("Ignored message from self {:?}", &message);
             Ok(())
         }
     }

--- a/statime/src/port/state/mod.rs
+++ b/statime/src/port/state/mod.rs
@@ -22,7 +22,7 @@ use crate::{
 mod master;
 mod slave;
 
-#[derive(Debug, Default)]
+#[derive(Clone, Debug, Default)]
 pub enum PortState {
     Disabled,
     #[default]

--- a/statime/src/port/state/slave.rs
+++ b/statime/src/port/state/slave.rs
@@ -11,7 +11,7 @@ use crate::{
 
 type Result<T, E = SlaveError> = core::result::Result<T, E>;
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct SlaveState {
     remote_master: PortIdentity,
 
@@ -30,7 +30,7 @@ impl SlaveState {
     }
 }
 
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 enum SyncState {
     Initial,
     AfterSync {
@@ -44,7 +44,7 @@ enum SyncState {
     },
 }
 
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 enum DelayState {
     Initial,
     AfterSync {

--- a/statime/src/ptp_instance.rs
+++ b/statime/src/ptp_instance.rs
@@ -27,7 +27,7 @@ pub struct PtpInstance<P, C, F, const N: usize> {
     current_ds: CurrentDS,
     parent_ds: ParentDS,
     time_properties_ds: TimePropertiesDS,
-    ports: [Port<P>; N],
+    pub ports: [Port<P>; N],
     local_clock: RefCell<C>,
     filter: RefCell<F>,
 }


### PR DESCRIPTION
NOTE: this is based on #109 

makes the linux setup sync (as in, not async) and exposes it as a function. this should be a good starting point for tests that simulate and verify PTP's behavior.