### PR TITLE
Tlv refactor

### DIFF
--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -19,9 +19,9 @@ checksum = "96d30a06541fbafbc7f82ed10c06164cfbd2c401138f6addd8404629c4b16711"
 
 [[package]]
 name = "atomic_refcell"
-version = "0.1.10"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79d6dc922a2792b006573f60b2648076355daeae5ce9cb59507e5908c9625d31"
+checksum = "112ef6b3f6cb3cb6fc5b6b494ef7a848492cff1ab0ef4de10b0f7d572861c905"
 
 [[package]]
 name = "az"
@@ -123,9 +123,9 @@ checksum = "f7012b1bbb0719e1097c47611d3898568c546d597c2e74d66f6087edd5233ff4"
 
 [[package]]
 name = "log"
-version = "0.4.19"
+version = "0.4.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b06a4cde4c0f271a446782e3eff8de789548ce57dbc8eca9292c27f4a42004b4"
+checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
 
 [[package]]
 name = "once_cell"

--- a/fuzz/fuzz_targets/message_sound.rs
+++ b/fuzz/fuzz_targets/message_sound.rs
@@ -4,12 +4,27 @@ use libfuzzer_sys::fuzz_target;
 use statime::FuzzMessage;
 
 fuzz_target!(|data: Vec<u8>| {
-    let mut buf1 = [0u8; 1024];
-    let mut buf2 = [0u8; 1024];
+    // the default maximum size a fuzzed Vec<_> will be, as per
+    //
+    // > INFO: -max_len is not provided; libFuzzer will not generate inputs larger
+    // than 4096 bytes
+    let mut buf1 = [0u8; 4096];
+    let mut buf2 = [0u8; 4096];
+
+    assert!(data.len() <= buf1.len());
+
     if let Ok(a) = FuzzMessage::deserialize(&data) {
-        a.serialize(&mut buf1).unwrap();
+        // verify that the tlv's are parsed without panics
+        for tlv in a.tlv() {
+            let _ = tlv;
+        }
+
+        let written = a.serialize(&mut buf1).unwrap();
+        assert_eq!(data.len(), written);
+
         let b = FuzzMessage::deserialize(&data).unwrap();
         b.serialize(&mut buf2).unwrap();
+
         assert_eq!(buf1, buf2);
     }
 });

--- a/statime/src/datastructures/messages/management.rs
+++ b/statime/src/datastructures/messages/management.rs
@@ -1,7 +1,4 @@
-use crate::datastructures::{
-    common::{PortIdentity, Tlv},
-    WireFormat, WireFormatError,
-};
+use crate::datastructures::{common::PortIdentity, WireFormat, WireFormatError};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct ManagementMessage {
@@ -9,12 +6,11 @@ pub(crate) struct ManagementMessage {
     pub(super) starting_boundary_hops: u8,
     pub(super) boundary_hops: u8,
     pub(super) action: ManagementAction,
-    pub(super) management_tlv: Tlv,
 }
 
 impl ManagementMessage {
     pub(crate) fn content_size(&self) -> usize {
-        10
+        14
     }
 
     pub(crate) fn serialize_content(
@@ -25,7 +21,6 @@ impl ManagementMessage {
         buffer[11] = self.starting_boundary_hops;
         buffer[12] = self.boundary_hops;
         buffer[13] = self.action.to_primitive();
-        Tlv::serialize(&self.management_tlv, &mut buffer[14..])?;
 
         Ok(())
     }
@@ -41,7 +36,6 @@ impl ManagementMessage {
             starting_boundary_hops: buffer[11],
             boundary_hops: buffer[12],
             action: ManagementAction::from_primitive(buffer[13]),
-            management_tlv: Tlv::deserialize(&buffer[13..])?,
         })
     }
 }

--- a/statime/src/datastructures/messages/mod.rs
+++ b/statime/src/datastructures/messages/mod.rs
@@ -1,7 +1,6 @@
 //! Ptp network messages
 
 pub(crate) use announce::*;
-use arrayvec::ArrayVec;
 pub(crate) use delay_req::*;
 pub(crate) use delay_resp::*;
 pub(crate) use follow_up::*;
@@ -13,7 +12,7 @@ use self::{
     p_delay_resp_follow_up::PDelayRespFollowUpMessage, signalling::SignalingMessage,
 };
 use super::{
-    common::{PortIdentity, TimeInterval, Tlv, WireTimestamp},
+    common::{PortIdentity, TimeInterval, TlvSet, WireTimestamp},
     datasets::DefaultDS,
 };
 use crate::{ptp_instance::PtpInstanceState, Interval, LeapIndicator, Time};
@@ -92,10 +91,10 @@ impl FuzzMessage {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub(crate) struct Message {
+pub(crate) struct Message<'a> {
     pub(crate) header: Header,
     pub(crate) body: MessageBody,
-    pub(crate) suffix: ArrayVec<Tlv, 4>,
+    pub(crate) suffix: TlvSet<'a>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -122,7 +121,7 @@ fn base_header(default_ds: &DefaultDS, port_identity: PortIdentity, sequence_id:
     }
 }
 
-impl Message {
+impl Message<'_> {
     pub(crate) fn sync(
         default_ds: &DefaultDS,
         port_identity: PortIdentity,
@@ -139,7 +138,7 @@ impl Message {
             body: MessageBody::Sync(SyncMessage {
                 origin_timestamp: current_time.into(),
             }),
-            suffix: ArrayVec::default(),
+            suffix: TlvSet::default(),
         }
     }
 
@@ -159,7 +158,7 @@ impl Message {
             body: MessageBody::FollowUp(FollowUpMessage {
                 precise_origin_timestamp: timestamp.into(),
             }),
-            suffix: ArrayVec::default(),
+            suffix: TlvSet::default(),
         }
     }
 
@@ -196,7 +195,7 @@ impl Message {
         Message {
             header,
             body,
-            suffix: ArrayVec::default(),
+            suffix: TlvSet::default(),
         }
     }
 
@@ -215,7 +214,7 @@ impl Message {
             body: MessageBody::DelayReq(DelayReqMessage {
                 origin_timestamp: WireTimestamp::default(),
             }),
-            suffix: ArrayVec::default(),
+            suffix: TlvSet::default(),
         }
     }
 
@@ -247,12 +246,12 @@ impl Message {
         Message {
             header,
             body,
-            suffix: ArrayVec::default(),
+            suffix: TlvSet::default(),
         }
     }
 }
 
-impl Message {
+impl Message<'_> {
     pub(crate) fn header(&self) -> &Header {
         &self.header
     }
@@ -363,7 +362,7 @@ impl Message {
         Ok(Message {
             header: header_data.header,
             body,
-            suffix: ArrayVec::default(),
+            suffix: TlvSet::default(),
         })
     }
 }

--- a/statime/src/datastructures/messages/mod.rs
+++ b/statime/src/datastructures/messages/mod.rs
@@ -73,13 +73,13 @@ impl TryFrom<u8> for MessageType {
 
 #[cfg(feature = "fuzz")]
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct FuzzMessage {
-    inner: Message,
+pub struct FuzzMessage<'a> {
+    inner: Message<'a>,
 }
 
 #[cfg(feature = "fuzz")]
-impl FuzzMessage {
-    pub fn deserialize(buffer: &[u8]) -> Result<Self, impl std::error::Error> {
+impl<'a> FuzzMessage<'a> {
+    pub fn deserialize(buffer: &'a [u8]) -> Result<Self, impl std::error::Error> {
         Ok::<FuzzMessage, super::WireFormatError>(FuzzMessage {
             inner: Message::deserialize(buffer)?,
         })
@@ -356,15 +356,17 @@ impl<'a> Message<'a> {
         let (header, rest) = buffer.split_at_mut(34);
         let (body, tlv) = rest.split_at_mut(self.body.wire_size());
 
-        self.header.serialize_header(
-            self.body.content_type(),
-            self.body.wire_size() + self.suffix.wire_size(),
-            header,
-        )?;
+        self.header
+            .serialize_header(
+                self.body.content_type(),
+                self.body.wire_size() + self.suffix.wire_size(),
+                header,
+            )
+            .unwrap();
 
-        self.body.serialize(body)?;
+        self.body.serialize(body).unwrap();
 
-        self.suffix.serialize(tlv)?;
+        self.suffix.serialize(tlv).unwrap();
 
         Ok(self.wire_size())
     }

--- a/statime/src/datastructures/messages/mod.rs
+++ b/statime/src/datastructures/messages/mod.rs
@@ -72,21 +72,35 @@ impl TryFrom<u8> for MessageType {
 }
 
 #[cfg(feature = "fuzz")]
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct FuzzMessage<'a> {
-    inner: Message<'a>,
-}
+pub use fuzz::FuzzMessage;
 
 #[cfg(feature = "fuzz")]
-impl<'a> FuzzMessage<'a> {
-    pub fn deserialize(buffer: &'a [u8]) -> Result<Self, impl std::error::Error> {
-        Ok::<FuzzMessage, super::WireFormatError>(FuzzMessage {
-            inner: Message::deserialize(buffer)?,
-        })
+mod fuzz {
+    use super::*;
+    use crate::datastructures::{common::Tlv, WireFormatError};
+
+    #[derive(Debug, Clone, PartialEq, Eq)]
+    pub struct FuzzMessage<'a> {
+        inner: Message<'a>,
     }
 
-    pub fn serialize(&self, buffer: &mut [u8]) -> Result<usize, impl std::error::Error> {
-        self.inner.serialize(buffer)
+    #[derive(Debug, Clone, PartialEq, Eq)]
+    pub struct FuzzTlv<'a>(Tlv<'a>);
+
+    impl<'a> FuzzMessage<'a> {
+        pub fn deserialize(buffer: &'a [u8]) -> Result<Self, impl std::error::Error> {
+            Ok::<FuzzMessage, WireFormatError>(FuzzMessage {
+                inner: Message::deserialize(buffer)?,
+            })
+        }
+
+        pub fn serialize(&self, buffer: &mut [u8]) -> Result<usize, impl std::error::Error> {
+            self.inner.serialize(buffer)
+        }
+
+        pub fn tlv(&self) -> impl Iterator<Item = FuzzTlv<'_>> + '_ {
+            self.inner.suffix.tlv().map(FuzzTlv)
+        }
     }
 }
 
@@ -346,7 +360,7 @@ impl<'a> Message<'a> {
 
     /// The byte size on the wire of this message
     pub(crate) fn wire_size(&self) -> usize {
-        self.header.wire_size() + self.body.wire_size()
+        self.header.wire_size() + self.body.wire_size() + self.suffix.wire_size()
     }
 
     /// Serializes the object into the PTP wire format.

--- a/statime/src/datastructures/messages/mod.rs
+++ b/statime/src/datastructures/messages/mod.rs
@@ -111,6 +111,94 @@ pub(crate) enum MessageBody {
     Management(ManagementMessage),
 }
 
+impl MessageBody {
+    fn wire_size(&self) -> usize {
+        match &self {
+            MessageBody::Sync(m) => m.content_size(),
+            MessageBody::DelayReq(m) => m.content_size(),
+            MessageBody::PDelayReq(m) => m.content_size(),
+            MessageBody::PDelayResp(m) => m.content_size(),
+            MessageBody::FollowUp(m) => m.content_size(),
+            MessageBody::DelayResp(m) => m.content_size(),
+            MessageBody::PDelayRespFollowUp(m) => m.content_size(),
+            MessageBody::Announce(m) => m.content_size(),
+            MessageBody::Signaling(m) => m.content_size(),
+            MessageBody::Management(m) => m.content_size(),
+        }
+    }
+
+    fn content_type(&self) -> MessageType {
+        match self {
+            MessageBody::Sync(_) => MessageType::Sync,
+            MessageBody::DelayReq(_) => MessageType::DelayReq,
+            MessageBody::PDelayReq(_) => MessageType::PDelayReq,
+            MessageBody::PDelayResp(_) => MessageType::PDelayResp,
+            MessageBody::FollowUp(_) => MessageType::FollowUp,
+            MessageBody::DelayResp(_) => MessageType::DelayResp,
+            MessageBody::PDelayRespFollowUp(_) => MessageType::PDelayRespFollowUp,
+            MessageBody::Announce(_) => MessageType::Announce,
+            MessageBody::Signaling(_) => MessageType::Signaling,
+            MessageBody::Management(_) => MessageType::Management,
+        }
+    }
+
+    pub(crate) fn serialize(&self, buffer: &mut [u8]) -> Result<usize, super::WireFormatError> {
+        match &self {
+            MessageBody::Sync(m) => m.serialize_content(buffer)?,
+            MessageBody::DelayReq(m) => m.serialize_content(buffer)?,
+            MessageBody::PDelayReq(m) => m.serialize_content(buffer)?,
+            MessageBody::PDelayResp(m) => m.serialize_content(buffer)?,
+            MessageBody::FollowUp(m) => m.serialize_content(buffer)?,
+            MessageBody::DelayResp(m) => m.serialize_content(buffer)?,
+            MessageBody::PDelayRespFollowUp(m) => m.serialize_content(buffer)?,
+            MessageBody::Announce(m) => m.serialize_content(buffer)?,
+            MessageBody::Signaling(m) => m.serialize_content(buffer)?,
+            MessageBody::Management(m) => m.serialize_content(buffer)?,
+        }
+
+        Ok(self.wire_size())
+    }
+
+    pub(crate) fn deserialize(
+        message_type: MessageType,
+        header: &Header,
+        buffer: &[u8],
+    ) -> Result<Self, super::WireFormatError> {
+        let body = match message_type {
+            MessageType::Sync => MessageBody::Sync(SyncMessage::deserialize_content(buffer)?),
+            MessageType::DelayReq => {
+                MessageBody::DelayReq(DelayReqMessage::deserialize_content(buffer)?)
+            }
+            MessageType::PDelayReq => {
+                MessageBody::PDelayReq(PDelayReqMessage::deserialize_content(buffer)?)
+            }
+            MessageType::PDelayResp => {
+                MessageBody::PDelayResp(PDelayRespMessage::deserialize_content(buffer)?)
+            }
+            MessageType::FollowUp => {
+                MessageBody::FollowUp(FollowUpMessage::deserialize_content(buffer)?)
+            }
+            MessageType::DelayResp => {
+                MessageBody::DelayResp(DelayRespMessage::deserialize_content(buffer)?)
+            }
+            MessageType::PDelayRespFollowUp => MessageBody::PDelayRespFollowUp(
+                PDelayRespFollowUpMessage::deserialize_content(buffer)?,
+            ),
+            MessageType::Announce => {
+                MessageBody::Announce(AnnounceMessage::deserialize_content(*header, buffer)?)
+            }
+            MessageType::Signaling => {
+                MessageBody::Signaling(SignalingMessage::deserialize_content(buffer)?)
+            }
+            MessageType::Management => {
+                MessageBody::Management(ManagementMessage::deserialize_content(buffer)?)
+            }
+        };
+
+        Ok(body)
+    }
+}
+
 fn base_header(default_ds: &DefaultDS, port_identity: PortIdentity, sequence_id: u16) -> Header {
     Header {
         sdo_id: default_ds.sdo_id,
@@ -251,44 +339,14 @@ impl Message<'_> {
     }
 }
 
-impl Message<'_> {
+impl<'a> Message<'a> {
     pub(crate) fn header(&self) -> &Header {
         &self.header
     }
 
     /// The byte size on the wire of this message
     pub(crate) fn wire_size(&self) -> usize {
-        self.header.wire_size() + self.content_size()
-    }
-
-    fn content_size(&self) -> usize {
-        match &self.body {
-            MessageBody::Sync(m) => m.content_size(),
-            MessageBody::DelayReq(m) => m.content_size(),
-            MessageBody::PDelayReq(m) => m.content_size(),
-            MessageBody::PDelayResp(m) => m.content_size(),
-            MessageBody::FollowUp(m) => m.content_size(),
-            MessageBody::DelayResp(m) => m.content_size(),
-            MessageBody::PDelayRespFollowUp(m) => m.content_size(),
-            MessageBody::Announce(m) => m.content_size(),
-            MessageBody::Signaling(m) => m.content_size(),
-            MessageBody::Management(m) => m.content_size(),
-        }
-    }
-
-    fn content_type(&self) -> MessageType {
-        match self.body {
-            MessageBody::Sync(_) => MessageType::Sync,
-            MessageBody::DelayReq(_) => MessageType::DelayReq,
-            MessageBody::PDelayReq(_) => MessageType::PDelayReq,
-            MessageBody::PDelayResp(_) => MessageType::PDelayResp,
-            MessageBody::FollowUp(_) => MessageType::FollowUp,
-            MessageBody::DelayResp(_) => MessageType::DelayResp,
-            MessageBody::PDelayRespFollowUp(_) => MessageType::PDelayRespFollowUp,
-            MessageBody::Announce(_) => MessageType::Announce,
-            MessageBody::Signaling(_) => MessageType::Signaling,
-            MessageBody::Management(_) => MessageType::Management,
-        }
+        self.header.wire_size() + self.body.wire_size()
     }
 
     /// Serializes the object into the PTP wire format.
@@ -296,22 +354,17 @@ impl Message<'_> {
     /// Returns the used buffer size that contains the message or an error.
     pub(crate) fn serialize(&self, buffer: &mut [u8]) -> Result<usize, super::WireFormatError> {
         let (header, rest) = buffer.split_at_mut(34);
+        let (body, tlv) = rest.split_at_mut(self.body.wire_size());
 
-        self.header
-            .serialize_header(self.content_type(), self.content_size(), header)?;
+        self.header.serialize_header(
+            self.body.content_type(),
+            self.body.wire_size() + self.suffix.wire_size(),
+            header,
+        )?;
 
-        match &self.body {
-            MessageBody::Sync(m) => m.serialize_content(rest)?,
-            MessageBody::DelayReq(m) => m.serialize_content(rest)?,
-            MessageBody::PDelayReq(m) => m.serialize_content(rest)?,
-            MessageBody::PDelayResp(m) => m.serialize_content(rest)?,
-            MessageBody::FollowUp(m) => m.serialize_content(rest)?,
-            MessageBody::DelayResp(m) => m.serialize_content(rest)?,
-            MessageBody::PDelayRespFollowUp(m) => m.serialize_content(rest)?,
-            MessageBody::Announce(m) => m.serialize_content(rest)?,
-            MessageBody::Signaling(m) => m.serialize_content(rest)?,
-            MessageBody::Management(m) => m.serialize_content(rest)?,
-        }
+        self.body.serialize(body)?;
+
+        self.suffix.serialize(tlv)?;
 
         Ok(self.wire_size())
     }
@@ -319,50 +372,27 @@ impl Message<'_> {
     /// Deserializes a message from the PTP wire format.
     ///
     /// Returns the message or an error.
-    pub(crate) fn deserialize(buffer: &[u8]) -> Result<Self, super::WireFormatError> {
+    pub(crate) fn deserialize(buffer: &'a [u8]) -> Result<Self, super::WireFormatError> {
         let header_data = Header::deserialize_header(buffer)?;
 
         // Skip the header bytes and only keep the content
         let content_buffer = &buffer[34..];
 
-        let body = match header_data.message_type {
-            MessageType::Sync => {
-                MessageBody::Sync(SyncMessage::deserialize_content(content_buffer)?)
-            }
-            MessageType::DelayReq => {
-                MessageBody::DelayReq(DelayReqMessage::deserialize_content(content_buffer)?)
-            }
-            MessageType::PDelayReq => {
-                MessageBody::PDelayReq(PDelayReqMessage::deserialize_content(content_buffer)?)
-            }
-            MessageType::PDelayResp => {
-                MessageBody::PDelayResp(PDelayRespMessage::deserialize_content(content_buffer)?)
-            }
-            MessageType::FollowUp => {
-                MessageBody::FollowUp(FollowUpMessage::deserialize_content(content_buffer)?)
-            }
-            MessageType::DelayResp => {
-                MessageBody::DelayResp(DelayRespMessage::deserialize_content(content_buffer)?)
-            }
-            MessageType::PDelayRespFollowUp => MessageBody::PDelayRespFollowUp(
-                PDelayRespFollowUpMessage::deserialize_content(content_buffer)?,
-            ),
-            MessageType::Announce => MessageBody::Announce(AnnounceMessage::deserialize_content(
-                header_data.header,
-                content_buffer,
-            )?),
-            MessageType::Signaling => {
-                MessageBody::Signaling(SignalingMessage::deserialize_content(content_buffer)?)
-            }
-            MessageType::Management => {
-                MessageBody::Management(ManagementMessage::deserialize_content(content_buffer)?)
-            }
-        };
+        let body = MessageBody::deserialize(
+            header_data.message_type,
+            &header_data.header,
+            content_buffer,
+        )?;
+
+        let tlv_buffer = &content_buffer
+            .get(body.wire_size()..)
+            .ok_or(super::WireFormatError::BufferTooShort)?;
+        let suffix = TlvSet::deserialize(tlv_buffer)?;
 
         Ok(Message {
             header: header_data.header,
             body,
-            suffix: TlvSet::default(),
+            suffix,
         })
     }
 }

--- a/statime/src/datastructures/messages/signalling.rs
+++ b/statime/src/datastructures/messages/signalling.rs
@@ -11,7 +11,7 @@ impl SignalingMessage {
     }
 
     pub(crate) fn serialize_content(&self, buffer: &mut [u8]) -> Result<(), WireFormatError> {
-        if buffer.len() < 11 {
+        if buffer.len() < 10 {
             return Err(WireFormatError::BufferTooShort);
         }
 

--- a/statime/src/datastructures/mod.rs
+++ b/statime/src/datastructures/mod.rs
@@ -13,6 +13,7 @@ pub(crate) enum WireFormatError {
     EnumConversionError,
     BufferTooShort,
     CapacityError,
+    Invalid,
 }
 
 impl core::fmt::Display for WireFormatError {
@@ -21,6 +22,7 @@ impl core::fmt::Display for WireFormatError {
             WireFormatError::EnumConversionError => f.write_str("enum conversion failed"),
             WireFormatError::BufferTooShort => f.write_str("a buffer is too short"),
             WireFormatError::CapacityError => f.write_str("a container has insufficient capacity"),
+            WireFormatError::Invalid => f.write_str("an invariant was violated"),
         }
     }
 }

--- a/statime/src/port/state/master.rs
+++ b/statime/src/port/state/master.rs
@@ -227,14 +227,13 @@ impl MasterState {
 
 #[cfg(test)]
 mod tests {
-    use arrayvec::ArrayVec;
     use fixed::types::{I48F16, U96F32};
 
     use super::*;
     use crate::{
         config::InstanceConfig,
         datastructures::{
-            common::{ClockIdentity, TimeInterval},
+            common::{ClockIdentity, TimeInterval, TlvSet},
             datasets::{CurrentDS, ParentDS},
             messages::{Header, SdoId},
         },
@@ -283,7 +282,7 @@ mod tests {
                 body: MessageBody::DelayReq(DelayReqMessage {
                     origin_timestamp: Time::from_micros(0).into(),
                 }),
-                suffix: ArrayVec::new(),
+                suffix: TlvSet::default(),
             },
             Time::from_fixed_nanos(U96F32::from_bits((200000 << 32) + (500 << 16))),
             Interval::from_log_2(2),
@@ -334,7 +333,7 @@ mod tests {
                 body: MessageBody::DelayReq(DelayReqMessage {
                     origin_timestamp: Time::from_micros(0).into(),
                 }),
-                suffix: ArrayVec::new(),
+                suffix: TlvSet::default(),
             },
             Time::from_fixed_nanos(U96F32::from_bits((220000 << 32) + (300 << 16))),
             Interval::from_log_2(5),

--- a/statime/src/port/state/slave.rs
+++ b/statime/src/port/state/slave.rs
@@ -384,13 +384,11 @@ impl SlaveState {
 
 #[cfg(test)]
 mod tests {
-    use arrayvec::ArrayVec;
-
     use super::*;
     use crate::{
         config::InstanceConfig,
         datastructures::{
-            common::{ClockIdentity, TimeInterval},
+            common::{ClockIdentity, TimeInterval, TlvSet},
             messages::{Header, SdoId},
         },
         Interval, MAX_DATA_LEN,
@@ -416,7 +414,7 @@ mod tests {
             Message {
                 header,
                 body,
-                suffix: ArrayVec::new(),
+                suffix: TlvSet::default(),
             },
             Time::from_micros(50),
         );
@@ -444,7 +442,7 @@ mod tests {
                 body: MessageBody::Sync(SyncMessage {
                     origin_timestamp: Time::from_micros(0).into(),
                 }),
-                suffix: ArrayVec::new(),
+                suffix: TlvSet::default(),
             },
             Time::from_micros(1050),
         );
@@ -464,7 +462,7 @@ mod tests {
                 body: MessageBody::FollowUp(FollowUpMessage {
                     precise_origin_timestamp: Time::from_micros(1000).into(),
                 }),
-                suffix: ArrayVec::new(),
+                suffix: TlvSet::default(),
             },
             PortIdentity::default(),
         );
@@ -494,7 +492,7 @@ mod tests {
                 body: MessageBody::Sync(SyncMessage {
                     origin_timestamp: Time::from_micros(0).into(),
                 }),
-                suffix: ArrayVec::new(),
+                suffix: TlvSet::default(),
             },
             Time::from_micros(50),
         );
@@ -571,7 +569,7 @@ mod tests {
             Message {
                 header,
                 body,
-                suffix: ArrayVec::new(),
+                suffix: TlvSet::default(),
             },
             PortIdentity::default(),
         );
@@ -599,7 +597,7 @@ mod tests {
                 body: MessageBody::Sync(SyncMessage {
                     origin_timestamp: Time::from_micros(0).into(),
                 }),
-                suffix: ArrayVec::new(),
+                suffix: TlvSet::default(),
             },
             Time::from_micros(1050),
         );
@@ -646,7 +644,7 @@ mod tests {
                 body: MessageBody::FollowUp(FollowUpMessage {
                     precise_origin_timestamp: Time::from_micros(1000).into(),
                 }),
-                suffix: ArrayVec::new(),
+                suffix: TlvSet::default(),
             },
             PortIdentity::default(),
         );
@@ -662,7 +660,7 @@ mod tests {
                     receive_timestamp: Time::from_micros(1255).into(),
                     requesting_port_identity: req_header.source_port_identity,
                 }),
-                suffix: ArrayVec::new(),
+                suffix: TlvSet::default(),
             },
             PortIdentity::default(),
         );
@@ -693,7 +691,7 @@ mod tests {
                 body: MessageBody::FollowUp(FollowUpMessage {
                     precise_origin_timestamp: Time::from_micros(10).into(),
                 }),
-                suffix: ArrayVec::new(),
+                suffix: TlvSet::default(),
             },
             PortIdentity::default(),
         );
@@ -711,7 +709,7 @@ mod tests {
                 body: MessageBody::Sync(SyncMessage {
                     origin_timestamp: Time::from_micros(0).into(),
                 }),
-                suffix: ArrayVec::new(),
+                suffix: TlvSet::default(),
             },
             Time::from_micros(50),
         );
@@ -743,7 +741,7 @@ mod tests {
                 body: MessageBody::Sync(SyncMessage {
                     origin_timestamp: Time::from_micros(0).into(),
                 }),
-                suffix: ArrayVec::new(),
+                suffix: TlvSet::default(),
             },
             Time::from_micros(50),
         );
@@ -761,7 +759,7 @@ mod tests {
                 body: MessageBody::FollowUp(FollowUpMessage {
                     precise_origin_timestamp: Time::from_micros(10).into(),
                 }),
-                suffix: ArrayVec::new(),
+                suffix: TlvSet::default(),
             },
             PortIdentity::default(),
         );
@@ -778,7 +776,7 @@ mod tests {
                 body: MessageBody::FollowUp(FollowUpMessage {
                     precise_origin_timestamp: Time::from_micros(10).into(),
                 }),
-                suffix: ArrayVec::new(),
+                suffix: TlvSet::default(),
             },
             PortIdentity::default(),
         );
@@ -803,7 +801,7 @@ mod tests {
                 body: MessageBody::Sync(SyncMessage {
                     origin_timestamp: Time::from_micros(0).into(),
                 }),
-                suffix: ArrayVec::new(),
+                suffix: TlvSet::default(),
             },
             Time::from_micros(50),
         );
@@ -823,7 +821,7 @@ mod tests {
                 body: MessageBody::Sync(SyncMessage {
                     origin_timestamp: Time::from_micros(0).into(),
                 }),
-                suffix: ArrayVec::new(),
+                suffix: TlvSet::default(),
             },
             Time::from_micros(1050),
         );
@@ -841,7 +839,7 @@ mod tests {
                 body: MessageBody::FollowUp(FollowUpMessage {
                     precise_origin_timestamp: Time::from_micros(1000).into(),
                 }),
-                suffix: ArrayVec::new(),
+                suffix: TlvSet::default(),
             },
             PortIdentity::default(),
         );
@@ -869,7 +867,7 @@ mod tests {
                 body: MessageBody::Sync(SyncMessage {
                     origin_timestamp: Time::from_micros(0).into(),
                 }),
-                suffix: ArrayVec::new(),
+                suffix: TlvSet::default(),
             },
             Time::from_micros(50),
         );
@@ -946,7 +944,7 @@ mod tests {
                         ..Default::default()
                     },
                 }),
-                suffix: ArrayVec::new(),
+                suffix: TlvSet::default(),
             },
             PortIdentity::default(),
         );
@@ -964,7 +962,7 @@ mod tests {
                     receive_timestamp: Time::from_micros(353).into(),
                     requesting_port_identity: req_header.source_port_identity,
                 }),
-                suffix: ArrayVec::new(),
+                suffix: TlvSet::default(),
             },
             PortIdentity::default(),
         );
@@ -982,7 +980,7 @@ mod tests {
                     receive_timestamp: Time::from_micros(253).into(),
                     requesting_port_identity: req_header.source_port_identity,
                 }),
-                suffix: ArrayVec::new(),
+                suffix: TlvSet::default(),
             },
             PortIdentity::default(),
         );


### PR DESCRIPTION
borrow the bytes of all tlv messages. That keeps the size of the `Message` struct small, and we never run out of capacity for tlv messages.

We do need the parsing facilities, so that we can decide which messages need to be propagated. 