### PR TITLE
Allow handling of general messages through handle_timecritical_receive.

### DIFF
--- a/statime/src/datastructures/messages/mod.rs
+++ b/statime/src/datastructures/messages/mod.rs
@@ -111,6 +111,21 @@ pub(crate) struct Message<'a> {
     pub(crate) suffix: TlvSet<'a>,
 }
 
+impl<'a> Message<'a> {
+    pub(crate) fn is_event(&self) -> bool {
+        use MessageBody::*;
+        match self.body {
+            Sync(_) | DelayReq(_) | PDelayReq(_) | PDelayResp(_) => true,
+            FollowUp(_)
+            | DelayResp(_)
+            | PDelayRespFollowUp(_)
+            | Announce(_)
+            | Signaling(_)
+            | Management(_) => false,
+        }
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) enum MessageBody {
     Sync(SyncMessage),


### PR DESCRIPTION
This is needed for ethernet transport support, as for that both general and event messages have the same ethertype and destination mac.