### PR TITLE
Renamed timecritical to event socket.

### DIFF
--- a/statime-linux/src/main.rs
+++ b/statime-linux/src/main.rs
@@ -493,7 +493,7 @@ async fn port_task<A: NetworkAddress + PtpTargetAddress>(
                     Ok(packet) => {
                         if let Some(timestamp) = packet.timestamp {
                             log::trace!("Recv timestamp: {:?}", packet.timestamp);
-                            port.handle_timecritical_receive(&event_buffer[..packet.bytes_read], timestamp_to_time(timestamp))
+                            port.handle_event_receive(&event_buffer[..packet.bytes_read], timestamp_to_time(timestamp))
                         } else {
                             log::error!("Missing recv timestamp");
                             PortActionIterator::empty()
@@ -562,7 +562,7 @@ async fn handle_actions<A: NetworkAddress + PtpTargetAddress>(
 
     for action in actions {
         match action {
-            PortAction::SendTimeCritical { context, data } => {
+            PortAction::SendEvent { context, data } => {
                 // send timestamp of the send
                 let time = event_socket
                     .send_to(data, A::PRIMARY_EVENT)

--- a/statime-stm32/Cargo.lock
+++ b/statime-stm32/Cargo.lock
@@ -52,9 +52,9 @@ dependencies = [
 
 [[package]]
 name = "atomic_refcell"
-version = "0.1.11"
+version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "112ef6b3f6cb3cb6fc5b6b494ef7a848492cff1ab0ef4de10b0f7d572861c905"
+checksum = "76f2bfe491d41d45507b8431da8274f7feeca64a49e86d980eed2937ec2ff020"
 
 [[package]]
 name = "autocfg"
@@ -259,9 +259,9 @@ checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
 name = "fixed"
-version = "1.23.1"
+version = "1.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79386fdcec5e0fde91b1a6a5bcd89677d1f9304f7f986b154a1b9109038854d9"
+checksum = "02c69ce7e7c0f17aa18fdd9d0de39727adb9c6281f2ad12f57cbe54ae6e76e7d"
 dependencies = [
  "az",
  "bytemuck",

--- a/statime-stm32/src/port.rs
+++ b/statime-stm32/src/port.rs
@@ -24,7 +24,7 @@ type StmPort<State> = statime::Port<State, Rng, &'static PtpClock, BasicFilter>;
 pub struct Port {
     timer_sender: Sender<'static, (TimerName, core::time::Duration), 4>,
     packet_id_sender: Sender<'static, (statime::TimestampContext, PacketId), 16>,
-    time_critical_socket: SocketHandle,
+    event_socket: SocketHandle,
     general_socket: SocketHandle,
     state: PortState,
 }
@@ -33,27 +33,27 @@ impl Port {
     pub fn new(
         timer_sender: Sender<'static, (TimerName, core::time::Duration), 4>,
         packet_id_sender: Sender<'static, (statime::TimestampContext, PacketId), 16>,
-        time_critical_socket: SocketHandle,
+        event_socket: SocketHandle,
         general_socket: SocketHandle,
         state: StmPort<InBmca<'static>>,
     ) -> Self {
         Self {
             timer_sender,
             packet_id_sender,
-            time_critical_socket,
+            event_socket,
             general_socket,
             state: PortState::InBmca(state),
         }
     }
 
-    pub fn handle_timecritical_receive(
+    pub fn handle_event_receive(
         &mut self,
         data: &[u8],
         timestamp: statime::Time,
         net: &mut impl Mutex<T = NetworkStack>,
     ) {
         let mut running_port_state = self.state.take_running();
-        let actions = running_port_state.handle_timecritical_receive(data, timestamp);
+        let actions = running_port_state.handle_event_receive(data, timestamp);
         self.handle_port_actions(actions, net);
         self.state.set_running(running_port_state);
     }
@@ -111,15 +111,15 @@ impl Port {
 
         for action in actions {
             match action {
-                PortAction::SendTimeCritical { context, data } => {
+                PortAction::SendEvent { context, data } => {
                     const TO: IpEndpoint = IpEndpoint {
                         addr: IpAddress::v4(224, 0, 1, 129),
                         port: 319,
                     };
-                    match send(net, self.time_critical_socket, &TO, data) {
+                    match send(net, self.event_socket, &TO, data) {
                         Ok(pid) => unwrap!(self.packet_id_sender.try_send((context, pid)).ok()),
                         Err(e) => {
-                            defmt::error!("Failed to send time critical packet, because: {}", e)
+                            defmt::error!("Failed to send event packet, because: {}", e)
                         }
                     }
                 }
@@ -164,8 +164,8 @@ impl Port {
         }
     }
 
-    pub fn time_critical_socket(&self) -> SocketHandle {
-        self.time_critical_socket
+    pub fn event_socket(&self) -> SocketHandle {
+        self.event_socket
     }
 
     pub fn general_socket(&self) -> SocketHandle {

--- a/statime/src/port/mod.rs
+++ b/statime/src/port/mod.rs
@@ -82,7 +82,7 @@ pub struct InBmca<'a> {
 }
 
 // Making this non-copy and non-clone ensures a single handle_send_timestamp
-// per SendTimeCritical
+// per SendEvent
 #[derive(Debug)]
 pub struct TimestampContext {
     inner: TimestampContextInner,
@@ -96,7 +96,7 @@ enum TimestampContextInner {
 
 #[derive(Debug)]
 pub enum PortAction<'a> {
-    SendTimeCritical {
+    SendEvent {
         context: TimestampContext,
         data: &'a [u8],
     },
@@ -123,7 +123,7 @@ pub enum PortAction<'a> {
 const MAX_ACTIONS: usize = 2;
 
 /// Guarantees to end user: Any set of actions will only ever contain a single
-/// time critical send
+/// event send
 #[derive(Debug)]
 #[must_use]
 pub struct PortActionIterator<'a> {
@@ -159,7 +159,7 @@ impl<'a> Iterator for PortActionIterator<'a> {
 }
 
 impl<'a, C: Clock, F: Filter, R: Rng> Port<Running<'a>, R, C, F> {
-    // Send timestamp for last timecritical message became available
+    // Send timestamp for last event message became available
     pub fn handle_send_timestamp(
         &mut self,
         context: TimestampContext,
@@ -228,12 +228,8 @@ impl<'a, C: Clock, F: Filter, R: Rng> Port<Running<'a>, R, C, F> {
         ]
     }
 
-    // Handle a message over the timecritical channel
-    pub fn handle_timecritical_receive(
-        &mut self,
-        data: &[u8],
-        timestamp: Time,
-    ) -> PortActionIterator {
+    // Handle a message over the event channel
+    pub fn handle_event_receive(&mut self, data: &[u8], timestamp: Time) -> PortActionIterator {
         let message = match Message::deserialize(data) {
             Ok(message) => message,
             Err(error) => {
@@ -715,7 +711,7 @@ mod tests {
     }
 
     #[test]
-    fn test_announce_receive_via_timecritical() {
+    fn test_announce_receive_via_event() {
         let default_ds = DefaultDS::new(InstanceConfig {
             clock_identity: Default::default(),
             priority_1: 255,
@@ -765,21 +761,21 @@ mod tests {
         let packet_len = announce_message.serialize(&mut packet).unwrap();
         let packet = &packet[..packet_len];
 
-        let mut actions = port.handle_timecritical_receive(packet, Time::from_micros(1));
+        let mut actions = port.handle_event_receive(packet, Time::from_micros(1));
         let Some(PortAction::ResetAnnounceReceiptTimer { .. }) = actions.next() else {
             panic!("Unexpected action");
         };
         assert!(actions.next().is_none());
         drop(actions);
 
-        let mut actions = port.handle_timecritical_receive(packet, Time::from_micros(2));
+        let mut actions = port.handle_event_receive(packet, Time::from_micros(2));
         let Some(PortAction::ResetAnnounceReceiptTimer { .. }) = actions.next() else {
             panic!("Unexpected action");
         };
         assert!(actions.next().is_none());
         drop(actions);
 
-        let mut actions = port.handle_timecritical_receive(packet, Time::from_micros(3));
+        let mut actions = port.handle_event_receive(packet, Time::from_micros(3));
         let Some(PortAction::ResetAnnounceReceiptTimer { .. }) = actions.next() else {
             panic!("Unexpected action");
         };

--- a/statime/src/port/mod.rs
+++ b/statime/src/port/mod.rs
@@ -254,9 +254,8 @@ impl<'a, A: AcceptableMasterList, C: Clock, F: Filter, R: Rng> Port<Running<'a>,
             },
         }
     }
-}
 
-// Handle a message over the event channel
+    // Handle a message over the event channel
     pub fn handle_event_receive(&mut self, data: &[u8], timestamp: Time) -> PortActionIterator {
         let message = match Message::deserialize(data) {
             Ok(message) => message,

--- a/statime/src/port/state/master.rs
+++ b/statime/src/port/state/master.rs
@@ -96,7 +96,7 @@ impl MasterState {
             PortAction::ResetSyncTimer {
                 duration: config.sync_interval.as_core_duration(),
             },
-            PortAction::SendTimeCritical {
+            PortAction::SendEvent {
                 context: TimestampContext {
                     inner: TimestampContextInner::Sync { id: seq_id },
                 },
@@ -437,7 +437,7 @@ mod tests {
             actions.next(),
             Some(PortAction::ResetSyncTimer { .. })
         ));
-        let Some(PortAction::SendTimeCritical { context, data }) = actions.next() else {
+        let Some(PortAction::SendEvent { context, data }) = actions.next() else {
             panic!("Unexpected action");
         };
         assert!(actions.next().is_none());
@@ -494,7 +494,7 @@ mod tests {
             actions.next(),
             Some(PortAction::ResetSyncTimer { .. })
         ));
-        let Some(PortAction::SendTimeCritical { context, data }) = actions.next() else {
+        let Some(PortAction::SendEvent { context, data }) = actions.next() else {
             panic!("Unexpected action");
         };
         assert!(actions.next().is_none());

--- a/statime/src/port/state/slave.rs
+++ b/statime/src/port/state/slave.rs
@@ -369,7 +369,7 @@ impl<F> SlaveState<F> {
 
         actions![
             PortAction::ResetDelayRequestTimer { duration },
-            PortAction::SendTimeCritical {
+            PortAction::SendEvent {
                 context: TimestampContext {
                     inner: TimestampContextInner::DelayReq { id: delay_id },
                 },
@@ -658,7 +658,7 @@ mod tests {
             panic!("Unexpected action");
         };
 
-        let Some(PortAction::SendTimeCritical { context, data }) = action.next() else {
+        let Some(PortAction::SendEvent { context, data }) = action.next() else {
             panic!("Unexpected action");
         };
         assert!(action.next().is_none());
@@ -749,7 +749,7 @@ mod tests {
             panic!("Unexpected action");
         };
 
-        let Some(PortAction::SendTimeCritical { context, data }) = action.next() else {
+        let Some(PortAction::SendEvent { context, data }) = action.next() else {
             panic!("Unexpected action");
         };
         assert!(action.next().is_none());
@@ -1100,7 +1100,7 @@ mod tests {
             panic!("Unexpected action");
         };
 
-        let Some(PortAction::SendTimeCritical { context, data }) = action.next() else {
+        let Some(PortAction::SendEvent { context, data }) = action.next() else {
             panic!("Unexpected action");
         };
 


### PR DESCRIPTION
This ensures the name matches better with the spec.