### PR TITLE
Added config defaults

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -13,7 +13,7 @@ interface = "enp0s31f6"
 announce_interval = 1
 sync_interval = 0
 announce_receipt_timeout = 3
-delay_asymetry = 0
+delay_asymmetry = 0
 delay_mechanism = 0
 
 [[port]]
@@ -21,5 +21,5 @@ interface = "enp0s31f6"
 announce_interval = 1
 sync_interval = 0
 announce_receipt_timeout = 3
-delay_asymetry = 0
+delay_asymmetry = 0
 delay_mechanism = 0


### PR DESCRIPTION
- Added default values to the config where applicable. Not entirely sure about `delay_asymmetry` and `delay_mechanism` as I didn't encounter them in the spec.

- Renamed `delay_asymmetry` as it contained a typo
- Added a test with minimal needed config

