### PR TITLE
Observability in library and statime linux

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -497,6 +497,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_test"
+version = "1.0.176"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a2f49ace1498612d14f7e0b8245519584db8299541dfe31a06374a828d620ab"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "socket2"
 version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -518,6 +527,7 @@ dependencies = [
  "log",
  "rand",
  "serde",
+ "serde_test",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -517,6 +517,7 @@ dependencies = [
  "libm",
  "log",
  "rand",
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,7 @@ tokio = "1.33"
 rand = { version = "0.8.5", default-features = false }
 serde = { version = "1.0.192", features = ["derive"] }
 serde_json = { version = "1.0.111" }
+serde_test = { version = "1.0.176" } 
 az = "1.2.1"
 fixed = "1.24"
 libm = "0.2.8"

--- a/statime/Cargo.toml
+++ b/statime/Cargo.toml
@@ -12,9 +12,10 @@ publish.workspace = true
 rust-version.workspace = true
 
 [features]
-default = ["std"]
+default = ["std", "serde"]
 std = []
 fuzz = ["std"]
+serde = ["dep:serde"]
 
 [dependencies]
 arrayvec.workspace = true
@@ -24,3 +25,4 @@ libm.workspace = true
 log = { workspace = true, default-features = false}
 rand = { workspace = true, default-features = false }
 atomic_refcell.workspace = true
+serde = { workspace = true, optional = true }

--- a/statime/Cargo.toml
+++ b/statime/Cargo.toml
@@ -26,3 +26,6 @@ log = { workspace = true, default-features = false}
 rand = { workspace = true, default-features = false }
 atomic_refcell.workspace = true
 serde = { workspace = true, optional = true }
+
+[dev-dependencies]
+serde_test.workspace = true

--- a/statime/src/bmc/bmca.rs
+++ b/statime/src/bmc/bmca.rs
@@ -10,7 +10,7 @@ use super::{
 use crate::{
     datastructures::{
         common::{PortIdentity, TimeInterval},
-        datasets::DefaultDS,
+        datasets::InternalDefaultDS,
         messages::{AnnounceMessage, Header},
     },
     port::state::PortState,
@@ -106,7 +106,7 @@ impl<A> Bmca<A> {
     /// If None is returned, then the port should remain in the same state as it
     /// is now.
     pub(crate) fn calculate_recommended_state(
-        own_data: &DefaultDS,
+        own_data: &InternalDefaultDS,
         best_global_announce_message: Option<BestAnnounceMessage>,
         best_port_announce_message: Option<BestAnnounceMessage>,
         port_state: &PortState,
@@ -130,7 +130,7 @@ impl<A> Bmca<A> {
     }
 
     fn calculate_recommended_state_low_class(
-        own_data: &DefaultDS,
+        own_data: &InternalDefaultDS,
         best_port_announce_message: Option<BestAnnounceMessage>,
     ) -> RecommendedState {
         let d0 = ComparisonDataset::from_own_data(own_data);
@@ -143,7 +143,7 @@ impl<A> Bmca<A> {
     }
 
     fn calculate_recommended_state_high_class(
-        own_data: &DefaultDS,
+        own_data: &InternalDefaultDS,
         best_global_announce_message: Option<BestAnnounceMessage>,
         best_port_announce_message: Option<BestAnnounceMessage>,
     ) -> RecommendedState {
@@ -287,8 +287,8 @@ impl BestAnnounceMessage {
 
 #[derive(Debug, PartialEq, Eq)]
 pub(crate) enum RecommendedState {
-    M1(DefaultDS),
-    M2(DefaultDS),
+    M1(InternalDefaultDS),
+    M2(InternalDefaultDS),
     M3(AnnounceMessage),
     P1(AnnounceMessage),
     P2(AnnounceMessage),
@@ -443,7 +443,7 @@ mod tests {
         assert_eq!(message1.compare(&message2), Ordering::Less)
     }
 
-    fn default_own_data() -> DefaultDS {
+    fn default_own_data() -> InternalDefaultDS {
         let clock_identity = Default::default();
         let priority_1 = 0;
         let priority_2 = 0;
@@ -451,7 +451,7 @@ mod tests {
         let slave_only = false;
         let sdo_id = Default::default();
 
-        DefaultDS::new(InstanceConfig {
+        InternalDefaultDS::new(InstanceConfig {
             clock_identity,
             priority_1,
             priority_2,
@@ -492,7 +492,7 @@ mod tests {
         let slave_only = false;
         let sdo_id = Default::default();
 
-        let mut own_data = DefaultDS::new(InstanceConfig {
+        let mut own_data = InternalDefaultDS::new(InstanceConfig {
             clock_identity,
             priority_1,
             priority_2,

--- a/statime/src/bmc/dataset_comparison.rs
+++ b/statime/src/bmc/dataset_comparison.rs
@@ -4,7 +4,7 @@ use core::cmp::Ordering;
 
 use crate::datastructures::{
     common::{ClockIdentity, ClockQuality, PortIdentity},
-    datasets::DefaultDS,
+    datasets::InternalDefaultDS,
     messages::AnnounceMessage,
 };
 
@@ -42,7 +42,7 @@ impl ComparisonDataset {
         }
     }
 
-    pub(crate) fn from_own_data(data: &DefaultDS) -> Self {
+    pub(crate) fn from_own_data(data: &InternalDefaultDS) -> Self {
         Self {
             gm_priority_1: data.priority_1,
             gm_identity: data.clock_identity,

--- a/statime/src/datastructures/common/clock_accuracy.rs
+++ b/statime/src/datastructures/common/clock_accuracy.rs
@@ -1,6 +1,7 @@
 use core::cmp::Ordering;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 /// How accurate the underlying clock device is expected to be when not
 /// synchronized.
 pub enum ClockAccuracy {
@@ -67,7 +68,8 @@ pub enum ClockAccuracy {
 }
 
 impl ClockAccuracy {
-    pub(crate) fn to_primitive(self) -> u8 {
+    /// Converts enum to u8 literals
+    pub fn to_primitive(self) -> u8 {
         match self {
             Self::Reserved => 0x00,
             Self::PS1 => 0x17,

--- a/statime/src/datastructures/common/clock_identity.rs
+++ b/statime/src/datastructures/common/clock_identity.rs
@@ -8,6 +8,7 @@ use crate::datastructures::{WireFormat, WireFormatError};
 ///
 /// For more details, see *IEEE1588-2019 section 7.5.2.2.2*.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ClockIdentity(pub [u8; 8]);
 
 impl ClockIdentity {
@@ -42,6 +43,21 @@ impl WireFormat for ClockIdentity {
 
     fn deserialize(buffer: &[u8]) -> Result<Self, WireFormatError> {
         Ok(Self(buffer[0..8].try_into().unwrap()))
+    }
+}
+
+#[cfg(feature = "std")]
+impl core::fmt::Display for ClockIdentity {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        for (i, val) in self.0.iter().enumerate() {
+            if i != 0 {
+                write!(f, ":")?;
+            }
+
+            write!(f, "{:02x}", val)?;
+        }
+
+        Ok(())
     }
 }
 

--- a/statime/src/datastructures/common/clock_quality.rs
+++ b/statime/src/datastructures/common/clock_quality.rs
@@ -3,6 +3,7 @@ use crate::datastructures::{WireFormat, WireFormatError};
 
 /// A description of the accuracy and type of a clock.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ClockQuality {
     /// The PTP clock class.
     ///

--- a/statime/src/datastructures/common/leap_indicator.rs
+++ b/statime/src/datastructures/common/leap_indicator.rs
@@ -1,5 +1,6 @@
 /// Describes upcoming leap seconds.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum LeapIndicator {
     #[default]
     /// No leap seconds will be added or removed on this UTC day.

--- a/statime/src/datastructures/common/port_identity.rs
+++ b/statime/src/datastructures/common/port_identity.rs
@@ -3,11 +3,12 @@ use crate::datastructures::{WireFormat, WireFormatError};
 
 /// Identity of a single port of a PTP instance
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default, PartialOrd, Ord)]
-pub(crate) struct PortIdentity {
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct PortIdentity {
     /// Identity of the clock this port is part of
-    pub(crate) clock_identity: ClockIdentity,
+    pub clock_identity: ClockIdentity,
     /// Index of the port (1-based).
-    pub(crate) port_number: u16,
+    pub port_number: u16,
 }
 
 impl WireFormat for PortIdentity {

--- a/statime/src/datastructures/common/time_source.rs
+++ b/statime/src/datastructures/common/time_source.rs
@@ -7,6 +7,7 @@
 /// For more details see *IEEE1588-2019 section 7.6.2.8*
 #[allow(missing_docs)] // These varaiants are pretty self explaining
 #[derive(Default, Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum TimeSource {
     AtomicClock,
     Gnss,

--- a/statime/src/datastructures/datasets/current.rs
+++ b/statime/src/datastructures/datasets/current.rs
@@ -1,7 +1,7 @@
 use crate::time::Duration;
 
 #[derive(Default, Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
-pub(crate) struct CurrentDS {
+pub(crate) struct InternalCurrentDS {
     pub(crate) steps_removed: u16,
     pub(crate) offset_from_master: Duration,
     pub(crate) mean_delay: Duration,

--- a/statime/src/datastructures/datasets/default.rs
+++ b/statime/src/datastructures/datasets/default.rs
@@ -14,7 +14,7 @@ use crate::{
 /// those related to timebase, which is contained in the
 /// [TimePropertiesDS](crate::TimePropertiesDS) dataset.
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
-pub(crate) struct DefaultDS {
+pub(crate) struct InternalDefaultDS {
     pub(crate) clock_identity: ClockIdentity,
     pub(crate) number_ports: u16,
     pub(crate) clock_quality: ClockQuality,
@@ -25,7 +25,7 @@ pub(crate) struct DefaultDS {
     pub(crate) sdo_id: SdoId,
 }
 
-impl DefaultDS {
+impl InternalDefaultDS {
     pub(crate) fn new(config: InstanceConfig) -> Self {
         Self {
             clock_identity: config.clock_identity,

--- a/statime/src/datastructures/datasets/mod.rs
+++ b/statime/src/datastructures/datasets/mod.rs
@@ -1,6 +1,6 @@
-pub(crate) use current::CurrentDS;
-pub(crate) use default::DefaultDS;
-pub(crate) use parent::ParentDS;
+pub(crate) use current::InternalCurrentDS;
+pub(crate) use default::InternalDefaultDS;
+pub(crate) use parent::InternalParentDS;
 pub use time_properties::TimePropertiesDS;
 
 mod current;

--- a/statime/src/datastructures/datasets/parent.rs
+++ b/statime/src/datastructures/datasets/parent.rs
@@ -1,9 +1,9 @@
-use super::DefaultDS;
+use super::InternalDefaultDS;
 use crate::datastructures::common::{ClockIdentity, ClockQuality, PortIdentity};
 
 // TODO: Discuss moving this (and TimePropertiesDS, ...) to slave?
 #[derive(Clone, Debug, Eq, PartialEq)]
-pub(crate) struct ParentDS {
+pub(crate) struct InternalParentDS {
     pub(crate) parent_port_identity: PortIdentity,
     pub(crate) parent_stats: bool,
     pub(crate) observed_parent_offset_scaled_log_variance: u16,
@@ -14,9 +14,9 @@ pub(crate) struct ParentDS {
     pub(crate) grandmaster_priority_2: u8,
 }
 
-impl ParentDS {
-    pub(crate) fn new(default_ds: DefaultDS) -> Self {
-        ParentDS {
+impl InternalParentDS {
+    pub(crate) fn new(default_ds: InternalDefaultDS) -> Self {
+        InternalParentDS {
             parent_port_identity: PortIdentity {
                 clock_identity: default_ds.clock_identity,
                 port_number: 0,

--- a/statime/src/datastructures/datasets/time_properties.rs
+++ b/statime/src/datastructures/datasets/time_properties.rs
@@ -7,13 +7,22 @@ use crate::datastructures::common::{LeapIndicator, TimeSource};
 ///
 /// For more details see *IEEE1588-2019 section 8.2.4*.
 #[derive(Default, Copy, Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct TimePropertiesDS {
-    pub(crate) current_utc_offset: Option<i16>,
-    pub(crate) leap_indicator: LeapIndicator,
-    pub(crate) time_traceable: bool,
-    pub(crate) frequency_traceable: bool,
-    pub(crate) ptp_timescale: bool,
-    pub(crate) time_source: TimeSource,
+    /// The offset off UTC time compared to TAI time in seconds.
+    pub current_utc_offset: Option<i16>,
+    /// Describes upcoming leap seconds.
+    pub leap_indicator: LeapIndicator,
+    /// Wheter the timescale is tracable to a primary reference
+    pub time_traceable: bool,
+    /// Wheter the frequence determining the timescale is tracable to a primary
+    /// reference. True when the timescale is PTP, false when the timescale is
+    /// ARB.
+    pub frequency_traceable: bool,
+    /// Wheter the timescale of the Grandmaster PTP Instance is PTP.
+    pub ptp_timescale: bool,
+    /// The time source used by the Grandmaster PTP instance.
+    pub time_source: TimeSource,
 }
 
 impl TimePropertiesDS {

--- a/statime/src/datastructures/messages/header.rs
+++ b/statime/src/datastructures/messages/header.rs
@@ -402,9 +402,21 @@ mod tests {
 
     #[test]
     fn sdo_id_checks() {
-        let sdo_id = SdoId::try_from(0xfff).unwrap();
-        assert_eq!(0xfff, u16::from(sdo_id));
+        use serde_test::{assert_de_tokens_error, assert_tokens, Token};
+        let correct_sdo_id = SdoId::try_from(0xfff).unwrap();
+        let faulty_sdo_id = SdoId::try_from(0x1000);
 
-        assert!(SdoId::try_from(0x1000).is_err());
+        assert_eq!(0xfff, u16::from(correct_sdo_id));
+        assert!(faulty_sdo_id.is_err());
+
+        assert_tokens(
+            &correct_sdo_id,
+            &[Token::NewtypeStruct { name: "SdoId" }, Token::U16(4095)],
+        );
+
+        assert_de_tokens_error::<SdoId>(
+            &[Token::NewtypeStruct { name: "SdoId" }, Token::U16(4096)],
+            "invalid type: newtype struct, expected a 12 bit value within the 0..=0xFFF range",
+        );
     }
 }

--- a/statime/src/datastructures/messages/header.rs
+++ b/statime/src/datastructures/messages/header.rs
@@ -157,6 +157,7 @@ impl Default for Header {
 /// assert!(SdoId::try_from(0x1000).is_err());
 /// ```
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SdoId(u16);
 
 impl core::fmt::Display for SdoId {

--- a/statime/src/datastructures/messages/mod.rs
+++ b/statime/src/datastructures/messages/mod.rs
@@ -13,7 +13,7 @@ pub(crate) use sync::*;
 use self::{management::ManagementMessage, signalling::SignalingMessage};
 use super::{
     common::{PortIdentity, TimeInterval, TlvSet, WireTimestamp},
-    datasets::DefaultDS,
+    datasets::InternalDefaultDS,
     WireFormatError,
 };
 use crate::{
@@ -223,7 +223,11 @@ impl MessageBody {
     }
 }
 
-fn base_header(default_ds: &DefaultDS, port_identity: PortIdentity, sequence_id: u16) -> Header {
+fn base_header(
+    default_ds: &InternalDefaultDS,
+    port_identity: PortIdentity,
+    sequence_id: u16,
+) -> Header {
     Header {
         sdo_id: default_ds.sdo_id,
         domain_number: default_ds.domain_number,
@@ -235,7 +239,7 @@ fn base_header(default_ds: &DefaultDS, port_identity: PortIdentity, sequence_id:
 
 impl Message<'_> {
     pub(crate) fn sync(
-        default_ds: &DefaultDS,
+        default_ds: &InternalDefaultDS,
         port_identity: PortIdentity,
         sequence_id: u16,
     ) -> Self {
@@ -254,7 +258,7 @@ impl Message<'_> {
     }
 
     pub(crate) fn follow_up(
-        default_ds: &DefaultDS,
+        default_ds: &InternalDefaultDS,
         port_identity: PortIdentity,
         sequence_id: u16,
         timestamp: Time,
@@ -310,7 +314,7 @@ impl Message<'_> {
     }
 
     pub(crate) fn delay_req(
-        default_ds: &DefaultDS,
+        default_ds: &InternalDefaultDS,
         port_identity: PortIdentity,
         sequence_id: u16,
     ) -> Self {
@@ -361,7 +365,7 @@ impl Message<'_> {
     }
 
     pub(crate) fn pdelay_req(
-        default_ds: &DefaultDS,
+        default_ds: &InternalDefaultDS,
         port_identity: PortIdentity,
         sequence_id: u16,
     ) -> Self {
@@ -375,7 +379,7 @@ impl Message<'_> {
     }
 
     pub(crate) fn pdelay_resp(
-        default_ds: &DefaultDS,
+        default_ds: &InternalDefaultDS,
         port_identity: PortIdentity,
         request_header: Header,
         timestamp: Time,
@@ -396,7 +400,7 @@ impl Message<'_> {
     }
 
     pub(crate) fn pdelay_resp_follow_up(
-        default_ds: &DefaultDS,
+        default_ds: &InternalDefaultDS,
         port_identity: PortIdentity,
         requestor_identity: PortIdentity,
         sequence_id: u16,

--- a/statime/src/filters/kalman.rs
+++ b/statime/src/filters/kalman.rs
@@ -98,7 +98,7 @@ fn chi_1(chi: f64) -> f64 {
     const A4: f64 = -1.453152027;
     const A5: f64 = 1.061405429;
 
-    let x = (chi / 2.).max(0.0).sqrt();
+    let x = (chi / 2.).sqrt();
     let t = 1. / (1. + P * x);
     (A1 * t + A2 * t * t + A3 * t * t * t + A4 * t * t * t * t + A5 * t * t * t * t * t)
         * (-(x * x)).exp()
@@ -181,7 +181,7 @@ impl MeasurementErrorEstimator {
                     );
                     log::info!(
                         "New uncertainty estimate: {}ns",
-                        self.measurement_variance(config).max(0.0).sqrt() * 1e9,
+                        self.measurement_variance(config).sqrt() * 1e9,
                     );
                 } else {
                     self.last_sync = Some((m.event_time, sync_offset));
@@ -200,7 +200,7 @@ impl MeasurementErrorEstimator {
                     );
                     log::info!(
                         "New uncertainty estimate: {}ns",
-                        self.measurement_variance(config).max(0.0).sqrt() * 1e9,
+                        self.measurement_variance(config).sqrt() * 1e9,
                     );
                 } else {
                     self.last_delay = Some((m.event_time, delay_offset));
@@ -443,7 +443,7 @@ impl BaseFilter {
     fn offset_uncertainty(&self, config: &KalmanConfiguration) -> f64 {
         self.0
             .as_ref()
-            .map(|inner| inner.uncertainty.entry(0, 0).max(0.0).sqrt())
+            .map(|inner| inner.uncertainty.entry(0, 0).sqrt())
             .unwrap_or(config.step_threshold.seconds())
     }
 
@@ -457,7 +457,7 @@ impl BaseFilter {
     fn freq_offset_uncertainty(&self, config: &KalmanConfiguration) -> f64 {
         self.0
             .as_ref()
-            .map(|inner| inner.uncertainty.entry(1, 1).max(0.0).sqrt())
+            .map(|inner| inner.uncertainty.entry(1, 1).sqrt())
             .unwrap_or(config.initial_frequency_uncertainty)
     }
 
@@ -471,7 +471,7 @@ impl BaseFilter {
     fn mean_delay_uncertainty(&self, config: &KalmanConfiguration) -> f64 {
         self.0
             .as_ref()
-            .map(|inner| inner.uncertainty.entry(2, 2).max(0.0).sqrt())
+            .map(|inner| inner.uncertainty.entry(2, 2).sqrt())
             .unwrap_or(config.step_threshold.seconds())
     }
 
@@ -531,7 +531,6 @@ impl Filter for KalmanFilter {
             wander: config.initial_wander,
             wander_measurement_error: measurement_error_estimator
                 .measurement_variance(&config)
-                .max(0.0)
                 .sqrt(),
             measurement_error_estimator,
             cur_frequency: None,
@@ -704,25 +703,20 @@ impl KalmanFilter {
     }
 
     fn wander_score_update(&mut self, uncertainty: f64, prediction: f64, actual: f64) {
-        log::info!(
-            "Wander uncertainty: {}ns",
-            uncertainty.max(0.0).sqrt() * 1e9
-        );
+        log::info!("Wander uncertainty: {}ns", uncertainty.sqrt() * 1e9);
         if self.wander_measurement_error
             > 10.0
                 * self
                     .measurement_error_estimator
                     .measurement_variance(&self.config)
-                    .max(0.0)
                     .sqrt()
         {
             self.wander_filter = self.running_filter.clone();
             self.wander_measurement_error = self
                 .measurement_error_estimator
                 .measurement_variance(&self.config)
-                .max(0.0)
                 .sqrt()
-        } else if uncertainty.max(0.0).sqrt() > 10.0 * self.wander_measurement_error {
+        } else if uncertainty.sqrt() > 10.0 * self.wander_measurement_error {
             log::info!(
                 "Wander update predict: {}ns, actual: {}ns",
                 prediction * 1e9,
@@ -730,8 +724,7 @@ impl KalmanFilter {
             );
             let p = 1.
                 - chi_1(
-                    sqr(actual - prediction)
-                        / (uncertainty + sqr(self.wander_measurement_error)).max(f64::EPSILON),
+                    sqr(actual - prediction) / (uncertainty + sqr(self.wander_measurement_error)),
                 );
             log::info!("p: {}", p);
             if p < self.config.precision_low_probability {
@@ -746,7 +739,6 @@ impl KalmanFilter {
             self.wander_measurement_error = self
                 .measurement_error_estimator
                 .measurement_variance(&self.config)
-                .max(0.0)
                 .sqrt();
         }
     }

--- a/statime/src/lib.rs
+++ b/statime/src/lib.rs
@@ -89,6 +89,7 @@ pub mod config;
 pub(crate) mod datastructures;
 pub mod filters;
 mod float_polyfill;
+pub mod observability;
 pub mod port;
 mod ptp_instance;
 pub mod time;

--- a/statime/src/observability/current.rs
+++ b/statime/src/observability/current.rs
@@ -1,0 +1,24 @@
+use crate::datastructures::datasets::InternalCurrentDS;
+
+/// A concrete implementation of the PTP Current dataset (IEEE1588-2019 section
+/// 8.2.2)
+#[derive(Debug, Default, Copy, Clone)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct CurrentDS {
+    /// See *IEEE1588-2019 section 8.2.2.2*.
+    pub steps_removed: u16,
+    /// See *IEEE1588-2019 section 8.2.2.3*.
+    pub offset_from_master: i128,
+    /// See *IEEE1588-2019 section 8.2.2.4*.
+    pub mean_delay: i128,
+}
+
+impl From<&InternalCurrentDS> for CurrentDS {
+    fn from(v: &InternalCurrentDS) -> Self {
+        Self {
+            steps_removed: v.steps_removed,
+            offset_from_master: v.offset_from_master.nanos_rounded(),
+            mean_delay: v.mean_delay.nanos_rounded(),
+        }
+    }
+}

--- a/statime/src/observability/default.rs
+++ b/statime/src/observability/default.rs
@@ -1,0 +1,43 @@
+use crate::datastructures::datasets::InternalDefaultDS;
+
+/// A concrete implementation of the PTP Current dataset (IEEE1588-2019 section
+/// 8.2.1)
+///
+/// See [InternalDefaultDS](crate::datastructures::datasets::InternalDefaultDS).
+#[derive(Debug, Copy, Clone)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct DefaultDS {
+    /// The identity of a PTP node.
+    /// See *IEEE1588-2019 section 8.2.1.2.2*.
+    pub clock_identity: crate::config::ClockIdentity,
+    /// The amount of PTP ports on this PTP instance.
+    /// See *IEEE1588-2019 section 8.2.1.2.3*.
+    pub number_ports: u16,
+    /// A description of the accuracy and type of a clock.
+    pub clock_quality: crate::config::ClockQuality,
+    /// See *IEEE1588-2019 section 8.2.1.4.1*.
+    pub priority_1: u8,
+    /// See *IEEE1588-2019 section 8.2.1.4.2*.
+    pub priority_2: u8,
+    /// See *IEEE1588-2019 section 8.2.1.4.3*.
+    pub domain_number: u8,
+    /// See *IEEE1588-2019 section  8.2.1.4.4*.
+    pub slave_only: bool,
+    /// See *IEEE1588-2019 section 7.1.4 table 2*.
+    pub sdo_id: crate::config::SdoId,
+}
+
+impl From<&InternalDefaultDS> for DefaultDS {
+    fn from(v: &InternalDefaultDS) -> Self {
+        Self {
+            clock_identity: v.clock_identity,
+            number_ports: v.number_ports,
+            clock_quality: v.clock_quality,
+            priority_1: v.priority_1,
+            priority_2: v.priority_2,
+            domain_number: v.domain_number,
+            slave_only: v.slave_only,
+            sdo_id: v.sdo_id,
+        }
+    }
+}

--- a/statime/src/observability/mod.rs
+++ b/statime/src/observability/mod.rs
@@ -1,0 +1,25 @@
+//! Serializable implementations of datastructures to be used for observability
+/// A concrete implementation of the PTP Current dataset (IEEE1588-2019 section 8.2.2)
+pub mod current;
+/// A concrete implementation of the PTP Default dataset (IEEE1588-2019 section 8.2.1)
+pub mod default;
+/// A concrete implementation of the PTP Parent dataset (IEEE1588-2019 section 8.2.3)
+pub mod parent;
+
+use crate::datastructures::datasets::TimePropertiesDS;
+
+use self::{current::CurrentDS, default::DefaultDS, parent::ParentDS};
+
+/// Observable version of the InstanceState struct
+#[derive(Debug, Copy, Clone)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct ObservableInstanceState {
+    /// A concrete implementation of the PTP Default dataset (IEEE1588-2019 section 8.2.1)
+    pub default_ds: DefaultDS,
+    /// A concrete implementation of the PTP Current dataset (IEEE1588-2019 section 8.2.2)
+    pub current_ds: CurrentDS,
+    /// A concrete implementation of the PTP Parent dataset (IEEE1588-2019 section 8.2.3)
+    pub parent_ds: ParentDS,
+    /// A concrete implementation of the PTP Time Properties dataset (IEEE1588-2019 section 8.2.4)
+    pub time_properties_ds: TimePropertiesDS,
+}

--- a/statime/src/observability/parent.rs
+++ b/statime/src/observability/parent.rs
@@ -1,0 +1,43 @@
+use crate::{
+    config::{ClockIdentity, ClockQuality},
+    datastructures::{common::PortIdentity, datasets::InternalParentDS},
+};
+
+/// A concrete implementation of the PTP Current dataset (IEEE1588-2019 section
+/// 8.2.3)
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct ParentDS {
+    /// See *IEEE1588-2019 section 8.2.3.2*.
+    pub parent_port_identity: PortIdentity,
+    /// See *IEEE1588-2019 section 8.2.3.3*.
+    pub parent_stats: bool,
+    /// See *IEEE1588-2019 section 8.2.3.4*.
+    pub observed_parent_offset_scaled_log_variance: u16,
+    /// See *IEEE1588-2019 section 8.2.3.5*.
+    pub observed_parent_clock_phase_change_rate: u32,
+    /// See *IEEE1588-2019 section 8.2.3.6*.
+    pub grandmaster_identity: ClockIdentity,
+    /// See *IEEE1588-2019 section 8.2.3.7*.
+    pub grandmaster_clock_quality: ClockQuality,
+    /// See *IEEE1588-2019 section 8.2.3.8*.
+    pub grandmaster_priority_1: u8,
+    /// See *IEEE1588-2019 section 8.2.3.9*.
+    pub grandmaster_priority_2: u8,
+}
+
+impl From<&InternalParentDS> for ParentDS {
+    fn from(v: &InternalParentDS) -> Self {
+        Self {
+            parent_port_identity: v.parent_port_identity,
+            parent_stats: v.parent_stats,
+            observed_parent_offset_scaled_log_variance: v
+                .observed_parent_offset_scaled_log_variance,
+            observed_parent_clock_phase_change_rate: v.observed_parent_clock_phase_change_rate,
+            grandmaster_identity: v.grandmaster_identity,
+            grandmaster_clock_quality: v.grandmaster_clock_quality,
+            grandmaster_priority_1: v.grandmaster_priority_1,
+            grandmaster_priority_2: v.grandmaster_priority_2,
+        }
+    }
+}

--- a/statime/src/port/bmca.rs
+++ b/statime/src/port/bmca.rs
@@ -5,7 +5,7 @@ use crate::{
     bmc::bmca::{BestAnnounceMessage, RecommendedState},
     config::{AcceptableMasterList, LeapIndicator, TimePropertiesDS, TimeSource},
     datastructures::{
-        datasets::{CurrentDS, DefaultDS, ParentDS},
+        datasets::{InternalCurrentDS, InternalDefaultDS, InternalParentDS},
         messages::Message,
     },
     filters::Filter,
@@ -73,9 +73,9 @@ impl<'a, A, C: Clock, F: Filter, R: Rng> Port<InBmca<'a>, A, R, C, F> {
         &mut self,
         recommended_state: RecommendedState,
         time_properties_ds: &mut TimePropertiesDS,
-        current_ds: &mut CurrentDS,
-        parent_ds: &mut ParentDS,
-        default_ds: &DefaultDS,
+        current_ds: &mut InternalCurrentDS,
+        parent_ds: &mut InternalParentDS,
+        default_ds: &InternalDefaultDS,
     ) {
         self.set_recommended_port_state(&recommended_state, default_ds);
 
@@ -134,7 +134,7 @@ impl<'a, A, C: Clock, F: Filter, R: Rng> Port<InBmca<'a>, A, R, C, F> {
     fn set_recommended_port_state(
         &mut self,
         recommended_state: &RecommendedState,
-        default_ds: &DefaultDS,
+        default_ds: &InternalDefaultDS,
     ) {
         match recommended_state {
             // TODO set things like steps_removed once they are added

--- a/statime/src/port/mod.rs
+++ b/statime/src/port/mod.rs
@@ -115,6 +115,7 @@ pub(crate) mod state;
 /// #         }
 /// #     }
 /// # }
+/// # let (instance_config, time_properties_ds) = unimplemented!();
 /// use rand::thread_rng;
 /// use statime::config::{AcceptAnyMaster, DelayMechanism, PortConfig};
 /// use statime::filters::BasicFilter;

--- a/statime/src/port/mod.rs
+++ b/statime/src/port/mod.rs
@@ -121,7 +121,6 @@ pub(crate) mod state;
 /// use statime::PtpInstance;
 /// use statime::time::Interval;
 ///
-/// # let (instance_config, time_properties_ds) = unimplemented!();
 /// let mut instance = PtpInstance::<BasicFilter>::new(instance_config, time_properties_ds);
 ///
 /// // TODO make these values sensible
@@ -631,7 +630,7 @@ mod tests {
     use super::*;
     use crate::{
         config::{AcceptAnyMaster, DelayMechanism, InstanceConfig, TimePropertiesDS},
-        datastructures::datasets::{DefaultDS, ParentDS},
+        datastructures::datasets::{InternalDefaultDS, InternalParentDS},
         filters::BasicFilter,
         time::{Duration, Interval, Time},
         Clock,
@@ -717,7 +716,7 @@ mod tests {
     }
 
     pub(super) fn setup_test_state() -> AtomicRefCell<PtpInstanceState> {
-        let default_ds = DefaultDS::new(InstanceConfig {
+        let default_ds = InternalDefaultDS::new(InstanceConfig {
             clock_identity: Default::default(),
             priority_1: 255,
             priority_2: 255,
@@ -726,7 +725,7 @@ mod tests {
             sdo_id: Default::default(),
         });
 
-        let parent_ds = ParentDS::new(default_ds);
+        let parent_ds = InternalParentDS::new(default_ds);
 
         let state = AtomicRefCell::new(PtpInstanceState {
             default_ds,

--- a/statime/src/ptp_instance.rs
+++ b/statime/src/ptp_instance.rs
@@ -74,7 +74,6 @@ use crate::{
 /// let mut instance = PtpInstance::<BasicFilter>::new(
 ///     instance_config,
 ///     time_properties_ds,
-///     instance_sender,
 /// );
 ///
 /// let mut port = instance.add_port(port_config, filter_config, clock, rng);

--- a/statime/src/ptp_instance.rs
+++ b/statime/src/ptp_instance.rs
@@ -251,7 +251,7 @@ impl<F: Filter> PtpInstance<F> {
         ObservableInstanceState {
             default_ds: (&state.default_ds).into(),
             current_ds: (&state.current_ds).into(),
-            parent_ds: (&state.parent_ds.clone()).into(),
+            parent_ds: (&state.parent_ds).into(),
             time_properties_ds: state.time_properties_ds,
         }
     }


### PR DESCRIPTION
This PR will add a Prometheus exporter, which will get its metrics from statime-linux via a Unix Domain Socket, very similar to how ntpd-rs does it.

It implements all currently available Instance datasets and exposes only a small set of metrics. The full exposure of metrics will be implemented in a separate PR 