### PR TITLE
ptp virtual clock

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -135,9 +135,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clap"
-version = "4.5.1"
+version = "4.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c918d541ef2913577a0f9566e9ce27cb35b6df072075769e0b26cb5a554520da"
+checksum = "ac495e00dcec98c83465d5ad66c5c4fabd652fd6686e7c6269b117e729a6f17b"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -145,9 +145,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.1"
+version = "4.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f3e7391dad68afb0c2ede1bf619f579a3dc9c2ec67f089baa397123a2f3d1eb"
+checksum = "c77ed9a32a62e6ca27175d00d29d05ca32e396ea1eb5fb01d8256b669cec7663"
 dependencies = [
  "anstream",
  "anstyle",
@@ -157,9 +157,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.0"
+version = "4.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "307bc0538d5f0f83b8248db3087aa92fe504e4691294d0c96c0eabc33f47ba47"
+checksum = "cf9804afaaf59a91e75b022a30fb7229a7901f60c755489cc61c9b423b836442"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -169,9 +169,9 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.7.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98cc8fbded0c607b7ba9dd60cd98df59af97e84d24e49c8557331cfc26d301ce"
+checksum = "702fc72eb24e5a1e48ce58027a675bc24edd52096d5397d4aea7c6dd9eca0bd1"
 
 [[package]]
 name = "clock-steering"
@@ -553,9 +553,9 @@ dependencies = [
 
 [[package]]
 name = "strsim"
-version = "0.11.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ee073c9e4cd00e28217186dbe12796d692868f432bf2e97ee73bed0c56dfa01"
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "syn"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -571,8 +571,7 @@ dependencies = [
 [[package]]
 name = "timestamped-socket"
 version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5caba8d0c821442603f7e148c7cfc34e916a8c7f66ac3ce56d8a7bf928acbd4"
+source = "git+https://github.com/cmeissl/timestamped-socket.git?branch=feature/bind_phc#9b1db03aa1cb055a8ef9a0a8cd08b284f47c6d53"
 dependencies = [
  "libc",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,3 +53,6 @@ timestamped-socket = "0.2.0"
 # our own crates used as dependencies, same version as the workspace version
 # NOTE: keep this part at the bottom of the file, do not change this line
 statime = { version = "0.1.0", path = "./statime" }
+
+[patch.crates-io]
+timestamped-socket = { git = 'https://github.com/cmeissl/timestamped-socket.git', branch = "feature/bind_phc" }

--- a/statime-linux/src/config/mod.rs
+++ b/statime-linux/src/config/mod.rs
@@ -62,6 +62,8 @@ pub struct PortConfig {
     pub delay_mechanism: DelayType,
     #[serde(default = "default_delay_interval")]
     pub delay_interval: i8,
+    #[serde(default)]
+    pub bind_phc: Option<u32>,
 }
 
 fn deserialize_loglevel<'de, D>(deserializer: D) -> Result<log::LevelFilter, D::Error>
@@ -297,6 +299,7 @@ interface = "enp0s31f6"
             delay_asymmetry: 0,
             delay_mechanism: crate::config::DelayType::E2E,
             delay_interval: 0,
+            bind_phc: None,
         };
 
         let expected = crate::config::Config {

--- a/statime-linux/src/main.rs
+++ b/statime-linux/src/main.rs
@@ -844,7 +844,7 @@ async fn handle_actions_ethernet(
                     // get_tai gives zero if this is a hardware clock, and the needed
                     // correction when this port uses software timestamping
                     time.seconds +=
-                        clock.get_tai_offset().expect("Unable to get tai offset") as libc::time_t;
+                        clock.get_tai_offset().expect("Unable to get tai offset") as i64;
                     log::trace!("Send timestamp {:?}", time);
                     pending_timestamp = Some((context, timestamp_to_time(time)));
                 } else {

--- a/statime-linux/src/socket.rs
+++ b/statime-linux/src/socket.rs
@@ -64,8 +64,9 @@ impl PtpTargetAddress for EthernetAddress {
 pub fn open_ipv4_event_socket(
     interface: InterfaceName,
     timestamping: InterfaceTimestampMode,
+    bind_phc: Option<u32>,
 ) -> std::io::Result<Socket<SocketAddrV4, Open>> {
-    let socket = open_interface_udp4(interface, EVENT_PORT, timestamping)?;
+    let socket = open_interface_udp4(interface, EVENT_PORT, timestamping, bind_phc)?;
     socket.join_multicast(SocketAddrV4::new(IPV4_PRIMARY_MULTICAST, 0), interface)?;
     socket.join_multicast(SocketAddrV4::new(IPV4_PDELAY_MULTICAST, 0), interface)?;
     Ok(socket)
@@ -74,7 +75,7 @@ pub fn open_ipv4_event_socket(
 pub fn open_ipv4_general_socket(
     interface: InterfaceName,
 ) -> std::io::Result<Socket<SocketAddrV4, Open>> {
-    let socket = open_interface_udp4(interface, GENERAL_PORT, InterfaceTimestampMode::None)?;
+    let socket = open_interface_udp4(interface, GENERAL_PORT, InterfaceTimestampMode::None, None)?;
     socket.join_multicast(SocketAddrV4::new(IPV4_PRIMARY_MULTICAST, 0), interface)?;
     socket.join_multicast(SocketAddrV4::new(IPV4_PDELAY_MULTICAST, 0), interface)?;
     Ok(socket)
@@ -83,8 +84,9 @@ pub fn open_ipv4_general_socket(
 pub fn open_ipv6_event_socket(
     interface: InterfaceName,
     timestamping: InterfaceTimestampMode,
+    bind_phc: Option<u32>,
 ) -> std::io::Result<Socket<SocketAddrV6, Open>> {
-    let socket = open_interface_udp6(interface, EVENT_PORT, timestamping)?;
+    let socket = open_interface_udp6(interface, EVENT_PORT, timestamping, bind_phc)?;
     socket.join_multicast(
         SocketAddrV6::new(IPV6_PRIMARY_MULTICAST, 0, 0, 0),
         interface,
@@ -96,7 +98,7 @@ pub fn open_ipv6_event_socket(
 pub fn open_ipv6_general_socket(
     interface: InterfaceName,
 ) -> std::io::Result<Socket<SocketAddrV6, Open>> {
-    let socket = open_interface_udp6(interface, GENERAL_PORT, InterfaceTimestampMode::None)?;
+    let socket = open_interface_udp6(interface, GENERAL_PORT, InterfaceTimestampMode::None, None)?;
     // Port, flowinfo and scope doesn't matter for join multicast
     socket.join_multicast(
         SocketAddrV6::new(IPV6_PRIMARY_MULTICAST, 0, 0, 0),
@@ -109,8 +111,9 @@ pub fn open_ipv6_general_socket(
 pub fn open_ethernet_socket(
     interface: InterfaceName,
     timestamping: InterfaceTimestampMode,
+    bind_phc: Option<u32>,
 ) -> std::io::Result<Socket<EthernetAddress, Open>> {
-    let socket = open_interface_ethernet(interface, PTP_ETHERTYPE, timestamping)?;
+    let socket = open_interface_ethernet(interface, PTP_ETHERTYPE, timestamping, bind_phc)?;
     socket.join_multicast(EthernetAddress::PRIMARY_EVENT, interface)?;
     socket.join_multicast(EthernetAddress::PDELAY_EVENT, interface)?;
     Ok(socket)


### PR DESCRIPTION
On `linux` we can [virtualize](https://lwn.net/Articles/859792/) a single hardware ptp clock. 
One possible use case for this is to synchronize multiple clock domains on the same interface.
As the real hardware clock will be left free running, we need to specify the index of the virtual clock to receive the correct hardware timestamps at socket creation time.

depends on https://github.com/pendulum-project/timestamped-socket/pull/30