### PR TITLE
Revert to 1588-2008 for recommended port state.

### DIFF
--- a/statime/src/bmc/bmca.rs
+++ b/statime/src/bmc/bmca.rs
@@ -111,7 +111,8 @@ impl<A> Bmca<A> {
         best_port_announce_message: Option<BestAnnounceMessage>,
         port_state: &PortState,
     ) -> Option<RecommendedState> {
-        if best_global_announce_message.is_none() && matches!(port_state, PortState::Listening) {
+        // We stick to the 1588-2008, assuming the change in 1588-2019 is in error
+        if best_port_announce_message.is_none() && matches!(port_state, PortState::Listening) {
             None
         } else if (1..=127).contains(&own_data.clock_quality.clock_class) {
             // only consider the best message of the port


### PR DESCRIPTION
The change to the recommended port state algorithm in 1588-2019 is likely in error, causing grandmaster clocks to get stuck in the listening state if any master is active on the network.