### PR TITLE
Wrap PTP instance's state in a generic mutex and handle Announce messages on slave ports

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -72,12 +72,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96d30a06541fbafbc7f82ed10c06164cfbd2c401138f6addd8404629c4b16711"
 
 [[package]]
-name = "atomic_refcell"
-version = "0.1.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41e67cd8309bbd06cd603a9e693a784ac2e5d1e955f11286e355089fcab3047c"
-
-[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -520,7 +514,6 @@ name = "statime"
 version = "0.2.0"
 dependencies = [
  "arrayvec",
- "atomic_refcell",
  "az",
  "fixed",
  "libm",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,6 @@ serde_test = { version = "1.0.176" }
 az = "1.2.1"
 fixed = "1.24"
 libm = "0.2.8"
-atomic_refcell = "0.1.13"
 
 clock-steering = "0.2.0"
 timestamped-socket = "0.2.0"

--- a/statime-linux/src/main.rs
+++ b/statime-linux/src/main.rs
@@ -435,7 +435,7 @@ async fn run(
     }
 }
 
-type BmcaPort = Port<InBmca<'static>, Option<Vec<ClockIdentity>>, StdRng, LinuxClock, KalmanFilter>;
+type BmcaPort = Port<'static, InBmca, Option<Vec<ClockIdentity>>, StdRng, LinuxClock, KalmanFilter>;
 
 // the Port task
 //

--- a/statime-linux/src/main.rs
+++ b/statime-linux/src/main.rs
@@ -3,6 +3,7 @@ use std::{
     future::Future,
     path::PathBuf,
     pin::{pin, Pin},
+    sync::RwLock,
 };
 
 use clap::Parser;
@@ -14,7 +15,7 @@ use statime::{
         InBmca, Measurement, Port, PortAction, PortActionIterator, TimestampContext, MAX_DATA_LEN,
     },
     time::Time,
-    PtpInstance,
+    PtpInstance, PtpInstanceState,
 };
 use statime_linux::{
     clock::LinuxClock,
@@ -364,7 +365,7 @@ async fn actual_main() {
 }
 
 async fn run(
-    instance: &'static PtpInstance<KalmanFilter>,
+    instance: &'static PtpInstance<KalmanFilter, RwLock<PtpInstanceState>>,
     bmca_notify_sender: tokio::sync::watch::Sender<bool>,
     instance_state_sender: tokio::sync::watch::Sender<ObservableInstanceState>,
     mut main_task_receivers: Vec<Receiver<BmcaPort>>,
@@ -435,7 +436,15 @@ async fn run(
     }
 }
 
-type BmcaPort = Port<'static, InBmca, Option<Vec<ClockIdentity>>, StdRng, LinuxClock, KalmanFilter>;
+type BmcaPort = Port<
+    'static,
+    InBmca,
+    Option<Vec<ClockIdentity>>,
+    StdRng,
+    LinuxClock,
+    KalmanFilter,
+    RwLock<PtpInstanceState>,
+>;
 
 // the Port task
 //

--- a/statime-stm32/Cargo.lock
+++ b/statime-stm32/Cargo.lock
@@ -51,12 +51,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "atomic_refcell"
-version = "0.1.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41e67cd8309bbd06cd603a9e693a784ac2e5d1e955f11286e355089fcab3047c"
-
-[[package]]
 name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -727,10 +721,9 @@ dependencies = [
 
 [[package]]
 name = "statime"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "arrayvec",
- "atomic_refcell",
  "az",
  "fixed",
  "libm",

--- a/statime-stm32/src/main.rs
+++ b/statime-stm32/src/main.rs
@@ -32,11 +32,15 @@ use crate::{
     ethernet::{generate_mac_address, recv_slice, UdpSocketResources},
     port::setup_statime,
     ptp_clock::stm_time_to_statime,
+    ptp_state_mutex::PtpStateMutex,
 };
 
 mod ethernet;
 mod port;
 mod ptp_clock;
+mod ptp_state_mutex;
+
+type StmPtpInstance = PtpInstance<BasicFilter, PtpStateMutex>;
 
 defmt::timestamp!("{=u64:iso8601ms}", {
     let time = stm32_eth::ptp::EthernetPTP::get_time();
@@ -235,7 +239,7 @@ mod app {
     #[task(shared = [net, ptp_port], priority = 1)]
     async fn instance_bmca(
         mut cx: instance_bmca::Context,
-        ptp_instance: &'static PtpInstance<BasicFilter>,
+        ptp_instance: &'static StmPtpInstance,
     ) {
         let net = &mut cx.shared.net;
         let ptp_port = &mut cx.shared.ptp_port;

--- a/statime-stm32/src/ptp_state_mutex.rs
+++ b/statime-stm32/src/ptp_state_mutex.rs
@@ -1,0 +1,20 @@
+use core::cell::RefCell;
+
+use critical_section::Mutex;
+use statime::{PtpInstanceState, PtpInstanceStateMutex};
+
+pub struct PtpStateMutex(Mutex<RefCell<PtpInstanceState>>);
+
+impl PtpInstanceStateMutex for PtpStateMutex {
+    fn new(state: PtpInstanceState) -> Self {
+        Self(Mutex::new(RefCell::new(state)))
+    }
+
+    fn with_ref<R, F: FnOnce(&PtpInstanceState) -> R>(&self, f: F) -> R {
+        critical_section::with(|cs| f(&self.0.borrow_ref(cs)))
+    }
+
+    fn with_mut<R, F: FnOnce(&mut PtpInstanceState) -> R>(&self, f: F) -> R {
+        critical_section::with(|cs| f(&mut self.0.borrow_ref_mut(cs)))
+    }
+}

--- a/statime/Cargo.toml
+++ b/statime/Cargo.toml
@@ -24,7 +24,6 @@ fixed.workspace = true
 libm.workspace = true
 log = { workspace = true, default-features = false}
 rand = { workspace = true, default-features = false }
-atomic_refcell.workspace = true
 serde = { workspace = true, optional = true }
 
 [dev-dependencies]

--- a/statime/src/lib.rs
+++ b/statime/src/lib.rs
@@ -95,7 +95,7 @@ mod ptp_instance;
 pub mod time;
 
 pub use clock::Clock;
-pub use ptp_instance::PtpInstance;
+pub use ptp_instance::{PtpInstance, PtpInstanceState, PtpInstanceStateMutex};
 
 /// Helper types used for fuzzing
 ///

--- a/statime/src/port/bmca.rs
+++ b/statime/src/port/bmca.rs
@@ -13,11 +13,14 @@ use crate::{
         state::{PortState, SlaveState},
         PortAction,
     },
+    ptp_instance::PtpInstanceStateMutex,
     time::Duration,
     Clock,
 };
 
-impl<'a, A: AcceptableMasterList, C: Clock, F: Filter, R: Rng> Port<'a, Running, A, R, C, F> {
+impl<'a, A: AcceptableMasterList, C: Clock, F: Filter, R: Rng, S: PtpInstanceStateMutex>
+    Port<'a, Running, A, R, C, F, S>
+{
     pub(super) fn handle_announce<'b>(
         &'b mut self,
         message: &Message<'b>,
@@ -38,13 +41,15 @@ impl<'a, A: AcceptableMasterList, C: Clock, F: Filter, R: Rng> Port<'a, Running,
 }
 
 // BMCA related functionality of the port
-impl<'a, A: AcceptableMasterList, C: Clock, F: Filter, R: Rng> Port<'a, InBmca, A, R, C, F> {
+impl<'a, A: AcceptableMasterList, C: Clock, F: Filter, R: Rng, S: PtpInstanceStateMutex>
+    Port<'a, InBmca, A, R, C, F, S>
+{
     pub(crate) fn calculate_best_local_announce_message(&mut self) {
         self.lifecycle.local_best = self.bmca.take_best_port_announce_message()
     }
 }
 
-impl<'a, A, C: Clock, F: Filter, R: Rng> Port<'a, InBmca, A, R, C, F> {
+impl<'a, A, C: Clock, F: Filter, R: Rng, S: PtpInstanceStateMutex> Port<'a, InBmca, A, R, C, F, S> {
     pub(crate) fn step_announce_age(&mut self, step: Duration) {
         self.bmca.step_age(step);
     }

--- a/statime/src/port/bmca.rs
+++ b/statime/src/port/bmca.rs
@@ -17,7 +17,7 @@ use crate::{
     Clock,
 };
 
-impl<'a, A: AcceptableMasterList, C: Clock, F: Filter, R: Rng> Port<Running<'a>, A, R, C, F> {
+impl<'a, A: AcceptableMasterList, C: Clock, F: Filter, R: Rng> Port<'a, Running, A, R, C, F> {
     pub(super) fn handle_announce<'b>(
         &'b mut self,
         message: &Message<'b>,
@@ -38,13 +38,13 @@ impl<'a, A: AcceptableMasterList, C: Clock, F: Filter, R: Rng> Port<Running<'a>,
 }
 
 // BMCA related functionality of the port
-impl<'a, A: AcceptableMasterList, C: Clock, F: Filter, R: Rng> Port<InBmca<'a>, A, R, C, F> {
+impl<'a, A: AcceptableMasterList, C: Clock, F: Filter, R: Rng> Port<'a, InBmca, A, R, C, F> {
     pub(crate) fn calculate_best_local_announce_message(&mut self) {
         self.lifecycle.local_best = self.bmca.take_best_port_announce_message()
     }
 }
 
-impl<'a, A, C: Clock, F: Filter, R: Rng> Port<InBmca<'a>, A, R, C, F> {
+impl<'a, A, C: Clock, F: Filter, R: Rng> Port<'a, InBmca, A, R, C, F> {
     pub(crate) fn step_announce_age(&mut self, step: Duration) {
         self.bmca.step_age(step);
     }

--- a/statime/src/port/slave.rs
+++ b/statime/src/port/slave.rs
@@ -16,7 +16,7 @@ use crate::{
     Clock,
 };
 
-impl<'a, A, C: Clock, F: Filter, R> Port<Running<'a>, A, R, C, F> {
+impl<'a, A, C: Clock, F: Filter, R> Port<'a, Running, A, R, C, F> {
     pub(super) fn handle_time_measurement<'b>(&mut self) -> PortActionIterator<'b> {
         if let Some(measurement) = self.extract_measurement() {
             // If the received message allowed the (slave) state to calculate its offset
@@ -447,7 +447,7 @@ impl<'a, A, C: Clock, F: Filter, R> Port<Running<'a>, A, R, C, F> {
     }
 }
 
-impl<'a, A, C: Clock, F: Filter, R: Rng> Port<Running<'a>, A, R, C, F> {
+impl<'a, A, C: Clock, F: Filter, R: Rng> Port<'a, Running, A, R, C, F> {
     pub(super) fn send_delay_request(&mut self) -> PortActionIterator {
         match self.config.delay_mechanism {
             DelayMechanism::E2E { interval } => self.send_e2e_delay_request(interval),
@@ -462,7 +462,7 @@ impl<'a, A, C: Clock, F: Filter, R: Rng> Port<Running<'a>, A, R, C, F> {
         let pdelay_id = self.pdelay_seq_ids.generate();
 
         let pdelay_req = Message::pdelay_req(
-            &self.lifecycle.state.borrow().default_ds,
+            &self.instance_state.borrow().default_ds,
             self.port_identity,
             pdelay_id,
         );
@@ -511,7 +511,7 @@ impl<'a, A, C: Clock, F: Filter, R: Rng> Port<Running<'a>, A, R, C, F> {
 
                 let delay_id = self.delay_seq_ids.generate();
                 let delay_req = Message::delay_req(
-                    &self.lifecycle.state.borrow().default_ds,
+                    &self.instance_state.borrow().default_ds,
                     self.port_identity,
                     delay_id,
                 );

--- a/statime/src/port/slave.rs
+++ b/statime/src/port/slave.rs
@@ -12,11 +12,12 @@ use crate::{
     },
     filters::Filter,
     port::{actions::TimestampContextInner, state::SyncState, PortAction, TimestampContext},
+    ptp_instance::PtpInstanceStateMutex,
     time::{Duration, Interval, Time},
     Clock,
 };
 
-impl<'a, A, C: Clock, F: Filter, R> Port<'a, Running, A, R, C, F> {
+impl<'a, A, C: Clock, F: Filter, R, S> Port<'a, Running, A, R, C, F, S> {
     pub(super) fn handle_time_measurement<'b>(&mut self) -> PortActionIterator<'b> {
         if let Some(measurement) = self.extract_measurement() {
             // If the received message allowed the (slave) state to calculate its offset
@@ -447,7 +448,9 @@ impl<'a, A, C: Clock, F: Filter, R> Port<'a, Running, A, R, C, F> {
     }
 }
 
-impl<'a, A, C: Clock, F: Filter, R: Rng> Port<'a, Running, A, R, C, F> {
+impl<'a, A, C: Clock, F: Filter, R: Rng, S: PtpInstanceStateMutex>
+    Port<'a, Running, A, R, C, F, S>
+{
     pub(super) fn send_delay_request(&mut self) -> PortActionIterator {
         match self.config.delay_mechanism {
             DelayMechanism::E2E { interval } => self.send_e2e_delay_request(interval),
@@ -461,11 +464,9 @@ impl<'a, A, C: Clock, F: Filter, R: Rng> Port<'a, Running, A, R, C, F> {
     ) -> PortActionIterator {
         let pdelay_id = self.pdelay_seq_ids.generate();
 
-        let pdelay_req = Message::pdelay_req(
-            &self.instance_state.borrow().default_ds,
-            self.port_identity,
-            pdelay_id,
-        );
+        let pdelay_req = self.instance_state.with_ref(|state| {
+            Message::pdelay_req(&state.default_ds, self.port_identity, pdelay_id)
+        });
         let message_length = match pdelay_req.serialize(&mut self.packet_buffer) {
             Ok(length) => length,
             Err(error) => {
@@ -510,11 +511,9 @@ impl<'a, A, C: Clock, F: Filter, R: Rng> Port<'a, Running, A, R, C, F> {
                 log::debug!("Starting new delay measurement");
 
                 let delay_id = self.delay_seq_ids.generate();
-                let delay_req = Message::delay_req(
-                    &self.instance_state.borrow().default_ds,
-                    self.port_identity,
-                    delay_id,
-                );
+                let delay_req = self.instance_state.with_ref(|state| {
+                    Message::delay_req(&state.default_ds, self.port_identity, delay_id)
+                });
 
                 let message_length = match delay_req.serialize(&mut self.packet_buffer) {
                     Ok(length) => length,

--- a/statime/src/port/slave.rs
+++ b/statime/src/port/slave.rs
@@ -462,7 +462,7 @@ impl<'a, A, C: Clock, F: Filter, R: Rng> Port<Running<'a>, A, R, C, F> {
         let pdelay_id = self.pdelay_seq_ids.generate();
 
         let pdelay_req = Message::pdelay_req(
-            &self.lifecycle.state.default_ds,
+            &self.lifecycle.state.borrow().default_ds,
             self.port_identity,
             pdelay_id,
         );
@@ -511,7 +511,7 @@ impl<'a, A, C: Clock, F: Filter, R: Rng> Port<Running<'a>, A, R, C, F> {
 
                 let delay_id = self.delay_seq_ids.generate();
                 let delay_req = Message::delay_req(
-                    &self.lifecycle.state.default_ds,
+                    &self.lifecycle.state.borrow().default_ds,
                     self.port_identity,
                     delay_id,
                 );

--- a/statime/src/ptp_instance.rs
+++ b/statime/src/ptp_instance.rs
@@ -100,7 +100,7 @@ pub(crate) struct PtpInstanceState {
 impl PtpInstanceState {
     fn bmca<A: AcceptableMasterList, C: Clock, F: Filter, R: Rng>(
         &mut self,
-        ports: &mut [&mut Port<InBmca<'_>, A, R, C, F>],
+        ports: &mut [&mut Port<'_, InBmca, A, R, C, F>],
         bmca_interval: Duration,
     ) {
         debug_assert_eq!(self.default_ds.number_ports as usize, ports.len());
@@ -200,7 +200,7 @@ impl<F: Filter> PtpInstance<F> {
         filter_config: F::Config,
         clock: C,
         rng: R,
-    ) -> Port<InBmca<'_>, A, R, C, F> {
+    ) -> Port<'_, InBmca, A, R, C, F> {
         self.log_bmca_interval
             .fetch_min(config.announce_interval.as_log_2(), Ordering::Relaxed);
         let mut state = self.state.borrow_mut();
@@ -226,7 +226,7 @@ impl<F: Filter> PtpInstance<F> {
     /// the slice!
     pub fn bmca<A: AcceptableMasterList, C: Clock, R: Rng>(
         &self,
-        ports: &mut [&mut Port<InBmca<'_>, A, R, C, F>],
+        ports: &mut [&mut Port<'_, InBmca, A, R, C, F>],
     ) {
         self.state.borrow_mut().bmca(
             ports,


### PR DESCRIPTION
This is a fix for https://github.com/pendulum-project/statime/issues/439 as discussed there.
The `PtpInstanceState` is now wrapped in a "generic" (not quite since Rust doesn't have higher-kinded generics) mutex type instead of `AtomicRefCell`. This allows for modification of the state while a port is in its `Running` lifecycle.
While this was required in order to fix the above-mentioned bug, I think it's also generally desirable since it enables implementation of other PTP options, e.g. path trace.
The default type for this mutex is `RefCell`. This ought to be sufficient for completely single threaded environments.
The library facing trait API is not quite as ergonomic as I would have hoped, requiring a closure. This was required to support mutexes like `critical_section::Mutex`, which themselves work via a closure. On the flip side it turns out this is actually easier to implement by consumers, as a more conventional mutex API would have required associated types for the mutex guards with complex lifetime bounds.