### PR TITLE
Add path trace support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -71,6 +71,9 @@ name = "arrayvec"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96d30a06541fbafbc7f82ed10c06164cfbd2c401138f6addd8404629c4b16711"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "az"

--- a/docs/man/statime.toml.5.md
+++ b/docs/man/statime.toml.5.md
@@ -38,6 +38,9 @@ will be indicated by each configuration setting shown.
 `priority2` = *priority* (**128**)
 :   A tie breaker for the best master clock algorithm in the range `0..256`. `0` being the highest priority and `255` the lowest.
 
+`path-trace` = *bool*
+:   The instance uses the path trace option. This allows detecting clock loops when enabled on all instances in the network.
+
 ## `[[port]]`
 
 `interface` = *interface name*

--- a/docs/man/statime.toml.5.md
+++ b/docs/man/statime.toml.5.md
@@ -33,10 +33,10 @@ will be indicated by each configuration setting shown.
 :   The "source domain identity" of this PTP instance. Together with the `domain` it identifies a domain.
 
 `priority1` = *priority* (**128**)
-:   A tie breaker for the best master clock algorithm in the range `0..256`. `0` being highest priority an `255` the lowest.
+:   A tie breaker for the best master clock algorithm in the range `0..256`. `0` being the highest priority and `255` the lowest.
 
 `priority2` = *priority* (**128**)
-:   A tie breaker for the best master clock algorithm in the range `0..256`. `0` being highest priority an `255` the lowest.
+:   A tie breaker for the best master clock algorithm in the range `0..256`. `0` being the highest priority and `255` the lowest.
 
 ## `[[port]]`
 

--- a/statime-linux/src/config/mod.rs
+++ b/statime-linux/src/config/mod.rs
@@ -30,6 +30,8 @@ pub struct Config {
     pub priority1: u8,
     #[serde(default = "default_priority2")]
     pub priority2: u8,
+    #[serde(default)]
+    pub path_trace: bool,
     #[serde(rename = "port")]
     pub ports: Vec<PortConfig>,
     #[serde(default)]
@@ -280,6 +282,7 @@ interface = "enp0s31f6"
             identity: None,
             priority1: 128,
             priority2: 128,
+            path_trace: false,
             ports: vec![expected_port],
             observability: ObservabilityConfig::default(),
         };

--- a/statime-linux/src/main.rs
+++ b/statime-linux/src/main.rs
@@ -230,6 +230,7 @@ async fn actual_main() {
             current_ds: instance.current_ds(),
             parent_ds: instance.parent_ds(),
             time_properties_ds: instance.time_properties_ds(),
+            path_trace_ds: instance.path_trace_ds(),
         });
     statime_linux::observer::spawn(&config, instance_state_receiver).await;
 
@@ -413,6 +414,7 @@ async fn run(
             current_ds: instance.current_ds(),
             parent_ds: instance.parent_ds(),
             time_properties_ds: instance.time_properties_ds(),
+            path_trace_ds: instance.path_trace_ds(),
         });
 
         let mut clock_states = vec![ClockSyncMode::FromSystem; internal_sync_senders.len()];

--- a/statime-linux/src/main.rs
+++ b/statime-linux/src/main.rs
@@ -210,6 +210,7 @@ async fn actual_main() {
         domain_number: config.domain,
         slave_only: false,
         sdo_id: SdoId::try_from(config.sdo_id).expect("sdo-id should be between 0 and 4095"),
+        path_trace: false,
     };
 
     let time_properties_ds =

--- a/statime-linux/src/main.rs
+++ b/statime-linux/src/main.rs
@@ -210,7 +210,7 @@ async fn actual_main() {
         domain_number: config.domain,
         slave_only: false,
         sdo_id: SdoId::try_from(config.sdo_id).expect("sdo-id should be between 0 and 4095"),
-        path_trace: false,
+        path_trace: config.path_trace,
     };
 
     let time_properties_ds =

--- a/statime-linux/src/observer.rs
+++ b/statime-linux/src/observer.rs
@@ -2,7 +2,7 @@ use std::{fs::Permissions, os::unix::prelude::PermissionsExt, path::Path, time::
 
 use statime::{
     config::TimePropertiesDS,
-    observability::{current::CurrentDS, default::DefaultDS, parent::ParentDS},
+    observability::{current::CurrentDS, default::DefaultDS, parent::ParentDS, PathTraceDS},
 };
 use tokio::{io::AsyncWriteExt, net::UnixStream, task::JoinHandle};
 
@@ -12,7 +12,7 @@ use crate::{
 };
 
 /// Observable version of the InstanceState struct
-#[derive(Debug, Copy, Clone, serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct ObservableInstanceState {
     /// A concrete implementation of the PTP Default dataset (IEEE1588-2019
     /// section 8.2.1)
@@ -26,6 +26,9 @@ pub struct ObservableInstanceState {
     /// A concrete implementation of the PTP Time Properties dataset
     /// (IEEE1588-2019 section 8.2.4)
     pub time_properties_ds: TimePropertiesDS,
+    /// A concrete implementation of the PTP Path Trace dataset (IEEE1588-2019
+    /// section 16.2.2)
+    pub path_trace_ds: PathTraceDS,
 }
 
 pub async fn spawn(

--- a/statime-stm32/src/port.rs
+++ b/statime-stm32/src/port.rs
@@ -286,6 +286,7 @@ pub fn setup_statime(
         domain_number: 0,
         slave_only: false,
         sdo_id: SdoId::default(),
+        path_trace: false,
     };
     let time_properties_ds =
         TimePropertiesDS::new_arbitrary_time(false, false, TimeSource::InternalOscillator);

--- a/statime/Cargo.toml
+++ b/statime/Cargo.toml
@@ -15,7 +15,7 @@ rust-version.workspace = true
 default = ["std", "serde"]
 std = []
 fuzz = ["std"]
-serde = ["dep:serde"]
+serde = ["dep:serde", "arrayvec/serde"]
 
 [dependencies]
 arrayvec.workspace = true

--- a/statime/src/bmc/bmca.rs
+++ b/statime/src/bmc/bmca.rs
@@ -497,6 +497,7 @@ mod tests {
         let domain_number = 0;
         let slave_only = false;
         let sdo_id = Default::default();
+        let path_trace = false;
 
         InternalDefaultDS::new(InstanceConfig {
             clock_identity,
@@ -505,6 +506,7 @@ mod tests {
             domain_number,
             slave_only,
             sdo_id,
+            path_trace,
         })
     }
 
@@ -538,6 +540,7 @@ mod tests {
         let domain_number = 0;
         let slave_only = false;
         let sdo_id = Default::default();
+        let path_trace = false;
 
         let mut own_data = InternalDefaultDS::new(InstanceConfig {
             clock_identity,
@@ -546,6 +549,7 @@ mod tests {
             domain_number,
             slave_only,
             sdo_id,
+            path_trace,
         });
 
         own_data.clock_quality.clock_class = 1;

--- a/statime/src/config/instance.rs
+++ b/statime/src/config/instance.rs
@@ -15,6 +15,7 @@ use crate::PtpInstance;
 ///     domain_number: 0,
 ///     sdo_id: SdoId::default(),
 ///     slave_only: false,
+///     path_trace: false,
 /// };
 /// ```
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
@@ -45,4 +46,7 @@ pub struct InstanceConfig {
 
     /// Whether this node may never become a master in the network
     pub slave_only: bool,
+
+    /// Whether the path trace option is enabled
+    pub path_trace: bool,
 }

--- a/statime/src/datastructures/datasets/mod.rs
+++ b/statime/src/datastructures/datasets/mod.rs
@@ -1,9 +1,11 @@
 pub(crate) use current::InternalCurrentDS;
 pub(crate) use default::InternalDefaultDS;
 pub(crate) use parent::InternalParentDS;
+pub(crate) use path_trace::InternalPathTraceDS;
 pub use time_properties::TimePropertiesDS;
 
 mod current;
 mod default;
 mod parent;
+mod path_trace;
 mod time_properties;

--- a/statime/src/datastructures/datasets/mod.rs
+++ b/statime/src/datastructures/datasets/mod.rs
@@ -1,7 +1,7 @@
 pub(crate) use current::InternalCurrentDS;
 pub(crate) use default::InternalDefaultDS;
 pub(crate) use parent::InternalParentDS;
-pub(crate) use path_trace::InternalPathTraceDS;
+pub use path_trace::PathTraceDS;
 pub use time_properties::TimePropertiesDS;
 
 mod current;

--- a/statime/src/datastructures/datasets/path_trace.rs
+++ b/statime/src/datastructures/datasets/path_trace.rs
@@ -2,15 +2,20 @@ use arrayvec::ArrayVec;
 
 use crate::datastructures::{common::ClockIdentity, messages::MAX_DATA_LEN};
 
-#[derive(Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
-pub(crate) struct InternalPathTraceDS {
-    pub(crate) list: ArrayVec<ClockIdentity, { MAX_DATA_LEN / 8 }>,
-    pub(crate) enable: bool,
+/// A concrete implementation of the PTP Path Trace dataset
+/// (IEEE1588-2019 section 16.2.2)
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct PathTraceDS {
+    /// See *IEEE1588-2019 section 16.2.2.2.1*.
+    pub list: ArrayVec<ClockIdentity, { MAX_DATA_LEN / 8 }>,
+    /// See *IEEE1588-2019 section 16.2.2.3.1*.
+    pub enable: bool,
 }
 
-impl InternalPathTraceDS {
+impl PathTraceDS {
     pub(crate) fn new(enable: bool) -> Self {
-        InternalPathTraceDS {
+        PathTraceDS {
             list: Default::default(),
             enable,
         }

--- a/statime/src/datastructures/datasets/path_trace.rs
+++ b/statime/src/datastructures/datasets/path_trace.rs
@@ -1,0 +1,18 @@
+use arrayvec::ArrayVec;
+
+use crate::datastructures::{common::ClockIdentity, messages::MAX_DATA_LEN};
+
+#[derive(Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+pub(crate) struct InternalPathTraceDS {
+    pub(crate) list: ArrayVec<ClockIdentity, { MAX_DATA_LEN / 8 }>,
+    pub(crate) enable: bool,
+}
+
+impl InternalPathTraceDS {
+    pub(crate) fn new(enable: bool) -> Self {
+        InternalPathTraceDS {
+            list: Default::default(),
+            enable,
+        }
+    }
+}

--- a/statime/src/observability/mod.rs
+++ b/statime/src/observability/mod.rs
@@ -8,3 +8,5 @@ pub mod default;
 /// A concrete implementation of the PTP Parent dataset (IEEE1588-2019 section
 /// 8.2.3)
 pub mod parent;
+
+pub use crate::datastructures::datasets::PathTraceDS;

--- a/statime/src/port/bmca.rs
+++ b/statime/src/port/bmca.rs
@@ -6,7 +6,7 @@ use crate::{
     config::{AcceptableMasterList, LeapIndicator, TimePropertiesDS, TimeSource},
     datastructures::{
         common::{ClockIdentity, TlvType},
-        datasets::{InternalCurrentDS, InternalDefaultDS, InternalParentDS, InternalPathTraceDS},
+        datasets::{InternalCurrentDS, InternalDefaultDS, InternalParentDS, PathTraceDS},
         messages::Message,
     },
     filters::Filter,
@@ -148,7 +148,7 @@ impl<'a, A, C: Clock, F: Filter, R: Rng, S: PtpInstanceStateMutex> Port<'a, InBm
     pub(crate) fn set_recommended_state(
         &mut self,
         recommended_state: RecommendedState,
-        path_trace_ds: &mut InternalPathTraceDS,
+        path_trace_ds: &mut PathTraceDS,
         time_properties_ds: &mut TimePropertiesDS,
         current_ds: &mut InternalCurrentDS,
         parent_ds: &mut InternalParentDS,
@@ -516,7 +516,7 @@ mod tests {
 
         let mut state_ref = state.borrow_mut();
         state_ref.parent_ds.parent_port_identity.clock_identity.0 = [1, 2, 3, 4, 5, 6, 7, 8];
-        state_ref.path_trace_ds = InternalPathTraceDS::new(true);
+        state_ref.path_trace_ds = PathTraceDS::new(true);
         drop(state_ref);
 
         let mut port = setup_test_port(&state);

--- a/statime/src/port/master.rs
+++ b/statime/src/port/master.rs
@@ -269,7 +269,7 @@ mod tests {
         config::DelayMechanism,
         datastructures::{
             common::{PortIdentity, TimeInterval},
-            datasets::InternalPathTraceDS,
+            datasets::PathTraceDS,
             messages::{Header, MessageBody},
         },
         port::{
@@ -473,7 +473,7 @@ mod tests {
         state_ref.default_ds.priority_2 = 128;
         state_ref.parent_ds.grandmaster_priority_1 = 15;
         state_ref.parent_ds.grandmaster_priority_2 = 128;
-        state_ref.path_trace_ds = InternalPathTraceDS::new(true);
+        state_ref.path_trace_ds = PathTraceDS::new(true);
 
         drop(state_ref);
 

--- a/statime/src/port/mod.rs
+++ b/statime/src/port/mod.rs
@@ -644,7 +644,7 @@ mod tests {
     use super::*;
     use crate::{
         config::{AcceptAnyMaster, DelayMechanism, InstanceConfig, TimePropertiesDS},
-        datastructures::datasets::{InternalDefaultDS, InternalParentDS},
+        datastructures::datasets::{InternalDefaultDS, InternalParentDS, InternalPathTraceDS},
         filters::BasicFilter,
         time::{Duration, Interval, Time},
         Clock,
@@ -764,6 +764,7 @@ mod tests {
             domain_number: 0,
             slave_only: false,
             sdo_id: Default::default(),
+            path_trace: false,
         });
 
         let parent_ds = InternalParentDS::new(default_ds);
@@ -773,6 +774,7 @@ mod tests {
             current_ds: Default::default(),
             parent_ds,
             time_properties_ds: Default::default(),
+            path_trace_ds: InternalPathTraceDS::new(false),
         });
         state
     }

--- a/statime/src/port/mod.rs
+++ b/statime/src/port/mod.rs
@@ -644,7 +644,7 @@ mod tests {
     use super::*;
     use crate::{
         config::{AcceptAnyMaster, DelayMechanism, InstanceConfig, TimePropertiesDS},
-        datastructures::datasets::{InternalDefaultDS, InternalParentDS, InternalPathTraceDS},
+        datastructures::datasets::{InternalDefaultDS, InternalParentDS, PathTraceDS},
         filters::BasicFilter,
         time::{Duration, Interval, Time},
         Clock,
@@ -774,7 +774,7 @@ mod tests {
             current_ds: Default::default(),
             parent_ds,
             time_properties_ds: Default::default(),
-            path_trace_ds: InternalPathTraceDS::new(false),
+            path_trace_ds: PathTraceDS::new(false),
         });
         state
     }

--- a/statime/src/ptp_instance.rs
+++ b/statime/src/ptp_instance.rs
@@ -15,8 +15,7 @@ use crate::{
     datastructures::{
         common::PortIdentity,
         datasets::{
-            InternalCurrentDS, InternalDefaultDS, InternalParentDS, InternalPathTraceDS,
-            TimePropertiesDS,
+            InternalCurrentDS, InternalDefaultDS, InternalParentDS, PathTraceDS, TimePropertiesDS,
         },
     },
     filters::Filter,
@@ -99,7 +98,7 @@ pub struct PtpInstanceState {
     pub(crate) default_ds: InternalDefaultDS,
     pub(crate) current_ds: InternalCurrentDS,
     pub(crate) parent_ds: InternalParentDS,
-    pub(crate) path_trace_ds: InternalPathTraceDS,
+    pub(crate) path_trace_ds: PathTraceDS,
     pub(crate) time_properties_ds: TimePropertiesDS,
 }
 
@@ -164,7 +163,7 @@ impl<F, S: PtpInstanceStateMutex> PtpInstance<F, S> {
                 default_ds,
                 current_ds: Default::default(),
                 parent_ds: InternalParentDS::new(default_ds),
-                path_trace_ds: InternalPathTraceDS::new(config.path_trace),
+                path_trace_ds: PathTraceDS::new(config.path_trace),
                 time_properties_ds,
             }),
             log_bmca_interval: AtomicI8::new(i8::MAX),
@@ -190,6 +189,11 @@ impl<F, S: PtpInstanceStateMutex> PtpInstance<F, S> {
     /// Return IEEE-1588 timePropertiesDS for introspection
     pub fn time_properties_ds(&self) -> TimePropertiesDS {
         self.state.with_ref(|s| s.time_properties_ds)
+    }
+
+    /// Return IEEE-1588 pathTraceDS for introspection
+    pub fn path_trace_ds(&self) -> PathTraceDS {
+        self.state.with_ref(|s| s.path_trace_ds.clone())
     }
 }
 

--- a/statime/src/ptp_instance.rs
+++ b/statime/src/ptp_instance.rs
@@ -14,7 +14,10 @@ use crate::{
     config::{InstanceConfig, PortConfig},
     datastructures::{
         common::PortIdentity,
-        datasets::{InternalCurrentDS, InternalDefaultDS, InternalParentDS, TimePropertiesDS},
+        datasets::{
+            InternalCurrentDS, InternalDefaultDS, InternalParentDS, InternalPathTraceDS,
+            TimePropertiesDS,
+        },
     },
     filters::Filter,
     observability::{current::CurrentDS, default::DefaultDS, parent::ParentDS},
@@ -66,6 +69,7 @@ use crate::{
 ///     domain_number: 0,
 ///     slave_only: false,
 ///     sdo_id: Default::default(),
+///     path_trace: false,
 /// };
 /// let time_properties_ds = TimePropertiesDS::new_arbitrary_time(false, false, TimeSource::InternalOscillator);
 ///
@@ -95,6 +99,7 @@ pub struct PtpInstanceState {
     pub(crate) default_ds: InternalDefaultDS,
     pub(crate) current_ds: InternalCurrentDS,
     pub(crate) parent_ds: InternalParentDS,
+    pub(crate) path_trace_ds: InternalPathTraceDS,
     pub(crate) time_properties_ds: TimePropertiesDS,
 }
 
@@ -132,6 +137,7 @@ impl PtpInstanceState {
             if let Some(recommended_state) = recommended_state {
                 port.set_recommended_state(
                     recommended_state,
+                    &mut self.path_trace_ds,
                     &mut self.time_properties_ds,
                     &mut self.current_ds,
                     &mut self.parent_ds,
@@ -158,6 +164,7 @@ impl<F, S: PtpInstanceStateMutex> PtpInstance<F, S> {
                 default_ds,
                 current_ds: Default::default(),
                 parent_ds: InternalParentDS::new(default_ds),
+                path_trace_ds: InternalPathTraceDS::new(config.path_trace),
                 time_properties_ds,
             }),
             log_bmca_interval: AtomicI8::new(i8::MAX),


### PR DESCRIPTION
This adds support for path trace option as described in section 16.2 of IEEE Std1588-2019.

The main purpose of this is loop detection. I've also found it rather useful for general debugging as it makes the path Announces take through the network visible. It is also a prerequisite for potential IEEE Std 802.1as (gPTP) support where this option is mandatory.