### PR TITLE
RFC: PTPv1 support

### DIFF
--- a/statime-linux/src/config/mod.rs
+++ b/statime-linux/src/config/mod.rs
@@ -64,6 +64,8 @@ pub struct PortConfig {
     pub delay_mechanism: DelayType,
     #[serde(default = "default_delay_interval")]
     pub delay_interval: i8,
+    #[serde(default)]
+    pub protocol_version: ProtocolVersion,
 }
 
 fn deserialize_acceptable_master_list<'de, D>(
@@ -116,6 +118,10 @@ impl From<PortConfig> for statime::config::PortConfig<Option<Vec<ClockIdentity>>
                     interval: Interval::from_log_2(pc.delay_interval),
                 },
             },
+            protocol_version: match pc.protocol_version {
+                ProtocolVersion::PTPv1 => statime::config::ProtocolVersion::PTPv1,
+                ProtocolVersion::PTPv2 => statime::config::ProtocolVersion::PTPv2,
+            },
         }
     }
 }
@@ -135,6 +141,14 @@ pub enum DelayType {
     #[default]
     E2E,
     P2P,
+}
+
+
+#[derive(Deserialize, Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum ProtocolVersion {
+    PTPv1,
+    #[default]
+    PTPv2,
 }
 
 impl Config {
@@ -275,6 +289,7 @@ interface = "enp0s31f6"
             delay_asymmetry: 0,
             delay_mechanism: crate::config::DelayType::E2E,
             delay_interval: 0,
+            protocol_version: crate::config::ProtocolVersion::PTPv2,
         };
 
         let expected = crate::config::Config {

--- a/statime-linux/src/main.rs
+++ b/statime-linux/src/main.rs
@@ -12,7 +12,7 @@ use statime::{
     config::{ClockIdentity, InstanceConfig, SdoId, TimePropertiesDS, TimeSource},
     filters::{Filter, KalmanConfiguration, KalmanFilter},
     port::{
-        is_message_buffer_compatible, InBmca, Measurement, Port, PortAction, PortActionIterator,
+        InBmca, Measurement, Port, PortAction, PortActionIterator,
         TimestampContext, MAX_DATA_LEN,
     },
     time::Time,
@@ -579,7 +579,7 @@ async fn port_task<A: NetworkAddress + PtpTargetAddress>(
             let mut actions = tokio::select! {
                 result = event_socket.recv(&mut event_buffer) => match result {
                     Ok(packet) => {
-                        if !is_message_buffer_compatible(&event_buffer[..packet.bytes_read]) {
+                        if !port.is_message_buffer_compatible(&event_buffer[..packet.bytes_read]) {
                             // do not spam with missing timestamp error in mixed-version PTPv1+v2 networks
                             PortActionIterator::empty()
                         } else if let Some(timestamp) = packet.timestamp {

--- a/statime/src/config/mod.rs
+++ b/statime/src/config/mod.rs
@@ -13,7 +13,7 @@ mod instance;
 mod port;
 
 pub use instance::InstanceConfig;
-pub use port::{DelayMechanism, PortConfig};
+pub use port::{DelayMechanism, PortConfig, ProtocolVersion};
 
 pub use crate::{
     bmc::acceptable_master::{AcceptAnyMaster, AcceptableMasterList},

--- a/statime/src/config/port.rs
+++ b/statime/src/config/port.rs
@@ -24,6 +24,15 @@ pub enum DelayMechanism {
     // No support for other delay mechanisms
 }
 
+/// PTP protocol revision
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
+pub enum ProtocolVersion {
+    /// IEEE 1588-2002
+    PTPv1,
+    /// IEEE 1588-2019
+    PTPv2,
+}
+
 /// Configuration items of the PTP PortDS dataset. Dynamical fields are kept
 /// as part of [crate::port::Port].
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
@@ -54,7 +63,18 @@ pub struct PortConfig<A> {
     pub delay_asymmetry: Duration,
     // Notes:
     // Fields specific for delay mechanism are kept as part of [DelayMechanism].
-    // Version is always 2.1, so not stored (versionNumber, minorVersionNumber)
+
+    /// PTP protocol version this port will use
+    pub protocol_version: ProtocolVersion,
+    // Notes: it is technically possible to run different versions of PTP on
+    // the same physical Ethernet interface (Dante devices do this when having
+    // AES67 enabled) - this way PTPv1-to-v2 or vice versa "converter" can be
+    // created.
+    // To do this in Statime, create multiple Port instances, route packets
+    // to `handle_*_receive` methods according to PTP version in packet's
+    // header and merge actions from `PortActionIterator`s.
+    // Not tested yet, beware of possible strange conditions like boundary clock
+    // loops.
 }
 
 impl<A> PortConfig<A> {

--- a/statime/src/datastructures/common/grandmaster_v1.rs
+++ b/statime/src/datastructures/common/grandmaster_v1.rs
@@ -1,0 +1,62 @@
+use crate::datastructures::{WireFormat, WireFormatError};
+
+// TODO make them configurable instead of constants
+pub(crate) const V2_COMPAT_PRIORITY1: u8 = 128;
+pub(crate) const V2_COMPAT_PRIORITY1_PREFERRED: u8 = 64;
+pub(crate) const V2_COMPAT_PRIORITY2: u8 = 128;
+
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, PartialOrd, Ord)]
+pub(crate) struct GrandmasterPropertiesV1 {
+    pub(crate) communication_technology: u8,
+    pub(crate) clock_uuid: [u8; 6],
+    pub(crate) port_id: u16,
+    pub(crate) sequence_id: u16,
+    pub(crate) clock_stratum: u8,
+    pub(crate) clock_identifier: [u8; 4],
+    pub(crate) clock_variance: i16,
+    pub(crate) preferred: bool,
+    pub(crate) is_boundary_clock: bool
+}
+
+impl WireFormat for GrandmasterPropertiesV1 {
+    /* fn wire_size(&self) -> usize {
+        28
+    } */
+    fn serialize(&self, buffer: &mut [u8]) -> Result<(), WireFormatError> {
+        buffer[0] = 0;
+        buffer[1] = self.communication_technology;
+        buffer[2..8].copy_from_slice(&self.clock_uuid);
+        buffer[8..10].copy_from_slice(&self.port_id.to_be_bytes());
+        buffer[10..12].copy_from_slice(&self.sequence_id.to_be_bytes());
+        buffer[12] = 0;
+        buffer[13] = 0;
+        buffer[14] = 0;
+        buffer[15] = self.clock_stratum;
+        buffer[16..20].copy_from_slice(&self.clock_identifier);
+        buffer[20] = 0;
+        buffer[21] = 0;
+        buffer[22..24].copy_from_slice(&self.clock_variance.to_be_bytes());
+        buffer[24] = 0;
+        buffer[25] = self.preferred as u8;
+        buffer[26] = 0;
+        buffer[27] = self.is_boundary_clock as u8;
+        Ok(())
+    }
+    fn deserialize(buffer: &[u8]) -> Result<Self, WireFormatError> {
+        match buffer.get(0..28) {
+            None => Err(WireFormatError::BufferTooShort),
+            Some(buf) => Ok(Self {
+                communication_technology: buf[1],
+                clock_uuid: buf[2..8].try_into().unwrap(),
+                port_id: u16::from_be_bytes(buf[8..10].try_into().unwrap()),
+                sequence_id: u16::from_be_bytes(buf[10..12].try_into().unwrap()),
+                clock_stratum: buf[15],
+                clock_identifier: buf[16..20].try_into().unwrap(),
+                clock_variance: i16::from_be_bytes(buf[22..24].try_into().unwrap()),
+                preferred: buf[25] > 0,
+                is_boundary_clock: buf[27] > 0
+            })
+        }
+    }
+}

--- a/statime/src/datastructures/common/mod.rs
+++ b/statime/src/datastructures/common/mod.rs
@@ -3,19 +3,23 @@
 mod clock_accuracy;
 mod clock_identity;
 mod clock_quality;
+mod grandmaster_v1;
 mod leap_indicator;
 mod port_identity;
 mod time_interval;
 mod time_source;
 mod timestamp;
+mod timestamp_v1;
 mod tlv;
 
 pub use clock_accuracy::*;
 pub use clock_identity::*;
 pub use clock_quality::*;
+pub use grandmaster_v1::*;
 pub use leap_indicator::*;
 pub(crate) use port_identity::*;
 pub(crate) use time_interval::*;
 pub use time_source::*;
 pub use timestamp::*;
+pub use timestamp_v1::*;
 pub use tlv::*;

--- a/statime/src/datastructures/common/port_identity.rs
+++ b/statime/src/datastructures/common/port_identity.rs
@@ -1,5 +1,5 @@
 use super::clock_identity::ClockIdentity;
-use crate::datastructures::{WireFormat, WireFormatError};
+use crate::datastructures::{messages_v1, WireFormat, WireFormatError};
 
 /// Identity of a single port of a PTP instance
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default, PartialOrd, Ord)]
@@ -23,6 +23,18 @@ impl WireFormat for PortIdentity {
             clock_identity: ClockIdentity::deserialize(&buffer[0..8])?,
             port_number: u16::from_be_bytes(buffer[8..10].try_into().unwrap()),
         })
+    }
+}
+
+impl PortIdentity {
+    pub fn from_v1_fields(uuid: [u8; 6], port: u16) -> Self {
+        Self {
+            clock_identity: ClockIdentity::from_mac_address(uuid),
+            port_number: port
+        }
+    }
+    pub fn from_v1_header(header: &messages_v1::Header) -> Self {
+        Self::from_v1_fields(header.source_uuid, header.source_port_id)
     }
 }
 

--- a/statime/src/datastructures/common/timestamp_v1.rs
+++ b/statime/src/datastructures/common/timestamp_v1.rs
@@ -1,0 +1,44 @@
+use crate::{datastructures::{WireFormat, WireFormatError}, time::Time};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, PartialOrd, Ord)]
+pub struct WireTimestampV1 {
+    /// The seconds field of the timestamp.
+    /// May wrap around (Y38K problem)
+    pub seconds: u32,
+    /// The nanoseconds field of the timestamp.
+    /// Must be less than 10^9
+    pub nanos: u32,
+}
+impl WireFormat for WireTimestampV1 {
+    fn serialize(&self, buffer: &mut [u8]) -> Result<(), WireFormatError> {
+        buffer[0..4].copy_from_slice(&self.seconds.to_be_bytes());
+        buffer[4..8].copy_from_slice(&self.nanos.to_be_bytes());
+        Ok(())
+    }
+    fn deserialize(buffer: &[u8]) -> Result<Self, WireFormatError> {
+        Ok(Self {
+            seconds: u32::from_be_bytes(buffer[0..4].try_into().unwrap()),
+            nanos: u32::from_be_bytes(buffer[4..8].try_into().unwrap()),
+        })
+    }
+}
+impl From<Time> for WireTimestampV1 {
+    fn from(instant: Time) -> Self {
+        WireTimestampV1 {
+            seconds: instant.secs() as u32, // TODO: will wrap-around in 2038
+            // TODO we need to account for this overflow in other parts of the code
+            nanos: instant.subsec_nanos(),
+        }
+    }
+}
+/* impl From<WireTimestampV1> for WireTimestamp {
+    fn from(v1: WireTimestampV1) -> Self {
+        Self { seconds: v1.seconds as u64, nanos: v1.nanos }
+    }
+}
+impl From<WireTimestamp> for WireTimestampV1 {
+    fn from(v2: WireTimestamp) -> Self {
+        Self { seconds: v2.seconds as u32, nanos: v2.nanos }
+    }
+}
+//hopefully won't be needed, TODO remove */

--- a/statime/src/datastructures/datasets/parent.rs
+++ b/statime/src/datastructures/datasets/parent.rs
@@ -1,5 +1,5 @@
 use super::InternalDefaultDS;
-use crate::datastructures::common::{ClockIdentity, ClockQuality, PortIdentity};
+use crate::datastructures::common::{ClockIdentity, ClockQuality, GrandmasterPropertiesV1, PortIdentity};
 
 // TODO: Discuss moving this (and TimePropertiesDS, ...) to slave?
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -9,6 +9,7 @@ pub(crate) struct InternalParentDS {
     pub(crate) grandmaster_clock_quality: ClockQuality,
     pub(crate) grandmaster_priority_1: u8,
     pub(crate) grandmaster_priority_2: u8,
+    pub(crate) grandmaster_v1: Option<GrandmasterPropertiesV1>,
 }
 
 impl InternalParentDS {
@@ -22,6 +23,7 @@ impl InternalParentDS {
             grandmaster_clock_quality: default_ds.clock_quality,
             grandmaster_priority_1: default_ds.priority_1,
             grandmaster_priority_2: default_ds.priority_2,
+            grandmaster_v1: None,
         }
     }
 }

--- a/statime/src/datastructures/messages_v1/control_field.rs
+++ b/statime/src/datastructures/messages_v1/control_field.rs
@@ -1,0 +1,34 @@
+use super::EnumConversionError;
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ControlField {
+    Sync,
+    DelayReq,
+    FollowUp,
+    DelayResp,
+    /* Management, */ // TOOD
+}
+impl ControlField {
+    pub fn to_primitive(self) -> u8 {
+        match self {
+            ControlField::Sync => 0x00,
+            ControlField::DelayReq => 0x01,
+            ControlField::FollowUp => 0x02,
+            ControlField::DelayResp => 0x03,
+            /* ControlField::Management => 0x04, */
+        }
+    }
+}
+impl TryFrom<u8> for ControlField {
+    type Error = EnumConversionError;
+    fn try_from(value: u8) -> Result<Self, Self::Error> {
+        use ControlField::*;
+        match value {
+            0x00 => Ok(Sync),
+            0x01 => Ok(DelayReq),
+            0x02 => Ok(FollowUp),
+            0x03 => Ok(DelayResp),
+            /* 0x04 => Ok(Management), */
+            _ => Err(EnumConversionError),
+        }
+    }
+}

--- a/statime/src/datastructures/messages_v1/delay_resp.rs
+++ b/statime/src/datastructures/messages_v1/delay_resp.rs
@@ -1,0 +1,37 @@
+use crate::datastructures::{
+    common::WireTimestampV1,
+    WireFormat, WireFormatError,
+};
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct DelayRespMessage {
+    pub(crate) receive_timestamp: WireTimestampV1,
+    pub(crate) requesting_source_communication_technology: u8,
+    pub(crate) requesting_source_uuid: [u8; 6],
+    pub(crate) requesting_source_port_id: u16,
+    pub(crate) requesting_source_sequence_id: u16,
+}
+impl DelayRespMessage {
+    pub(crate) fn content_size(&self) -> usize {
+        20
+    }
+    pub(crate) fn serialize_content(&self, buffer: &mut [u8]) -> Result<(), WireFormatError> {
+        self.receive_timestamp.serialize(&mut buffer[0..8])?;
+        buffer[8] = 0;
+        buffer[9] = self.requesting_source_communication_technology;
+        buffer[10..16].copy_from_slice(&self.requesting_source_uuid);
+        buffer[16..18].copy_from_slice(&self.requesting_source_port_id.to_be_bytes());
+        buffer[18..20].copy_from_slice(&self.requesting_source_sequence_id.to_be_bytes());
+        Ok(())
+    }
+    pub(crate) fn deserialize_content(buffer: &[u8]) -> Result<Self, WireFormatError> {
+        let buf = buffer.get(0..20).ok_or(WireFormatError::BufferTooShort)?;
+        let receive_timestamp = WireTimestampV1::deserialize(&buf[0..8])?;
+        Ok(Self {
+            receive_timestamp,
+            requesting_source_communication_technology: buf[9],
+            requesting_source_uuid: buf[10..16].try_into().unwrap(),
+            requesting_source_port_id: u16::from_be_bytes(buf[16..18].try_into().unwrap()),
+            requesting_source_sequence_id: u16::from_be_bytes(buf[18..20].try_into().unwrap()),
+        })
+    }
+}

--- a/statime/src/datastructures/messages_v1/follow_up.rs
+++ b/statime/src/datastructures/messages_v1/follow_up.rs
@@ -1,0 +1,25 @@
+use crate::datastructures::{common::WireTimestampV1, WireFormat, WireFormatError};
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct FollowUpMessage {
+    pub(crate) associated_sequence_id: u16,
+    pub(crate) precise_origin_timestamp: WireTimestampV1,
+}
+impl FollowUpMessage {
+    pub(crate) fn content_size(&self) -> usize {
+        12
+    }
+    pub(crate) fn serialize_content(&self, buffer: &mut [u8]) -> Result<(), WireFormatError> {
+        buffer[0..2].copy_from_slice(&self.associated_sequence_id.to_be_bytes());
+        self.precise_origin_timestamp
+            .serialize(&mut buffer[2..10])?;
+        Ok(())
+    }
+    pub(crate) fn deserialize_content(buffer: &[u8]) -> Result<Self, WireFormatError> {
+        let slice = buffer.get(4..12).ok_or(WireFormatError::BufferTooShort)?;
+        let precise_origin_timestamp = WireTimestampV1::deserialize(slice)?;
+        Ok(Self {
+            associated_sequence_id: u16::from_be_bytes(buffer[2..4].try_into().unwrap()),
+            precise_origin_timestamp,
+        })
+    }
+}

--- a/statime/src/datastructures/messages_v1/header.rs
+++ b/statime/src/datastructures/messages_v1/header.rs
@@ -1,0 +1,115 @@
+use super::{control_field::ControlField, PortType};
+use crate::datastructures::WireFormatError;
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Header {
+    pub(crate) version_ptp: u16,
+    pub(crate) version_network: u16,
+    pub(crate) subdomain: [u8; 16],
+    // port_type specially handled
+    pub(crate) source_communication_technology: u8,
+    pub(crate) source_uuid: [u8; 6],
+    pub(crate) source_port_id: u16,
+    pub(crate) sequence_id: u16,
+    // control specially handled
+    pub(crate) leap61: bool,
+    pub(crate) leap59: bool,
+    pub(crate) ptp_boundary_clock: bool,
+    pub(crate) ptp_assist: bool,
+    pub(crate) ptp_ext_sync: bool,
+    pub(crate) parent_stats: bool,
+    pub(crate) ptp_sync_burst: bool,
+}
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct DeserializedHeader {
+    pub(crate) header: Header,
+    pub(crate) control: ControlField,
+    //pub(crate) message_length: usize,
+}
+impl Header {
+    pub(super) fn new() -> Self {
+        Self {
+            version_ptp: 1,
+            version_network: 1,
+            subdomain: [b'_', b'D', b'F', b'L', b'T', 0,0,0,0,0,0,0,0,0,0,0],
+            source_communication_technology: 1,
+            source_uuid: [0,0,0,0,0,0],
+            source_port_id: 0,
+            sequence_id: 0,
+            leap59: false,
+            leap61: false,
+            ptp_boundary_clock: false,
+            ptp_assist: false,
+            ptp_ext_sync: false,
+            parent_stats: false,
+            ptp_sync_burst: false
+        }
+    }
+    pub(crate) fn wire_size(&self) -> usize {
+        40
+    }
+    pub(crate) fn serialize_header(
+        &self,
+        control: ControlField,
+        _content_length: usize,
+        buffer: &mut [u8],
+    ) -> Result<(), WireFormatError> {
+        let port_type = match control {
+            ControlField::Sync | ControlField::DelayReq => PortType::Event,
+            _ => PortType::General
+        };
+        buffer[0..2].copy_from_slice(&self.version_ptp.to_be_bytes());
+        buffer[2..4].copy_from_slice(&self.version_network.to_be_bytes());
+        buffer[4..20].copy_from_slice(&self.subdomain);
+        buffer[20] = port_type as u8;
+        buffer[21] = self.source_communication_technology;
+        buffer[22..28].copy_from_slice(&self.source_uuid);
+        buffer[28..30].copy_from_slice(&self.source_port_id.to_be_bytes());
+        buffer[30..32].copy_from_slice(&self.sequence_id.to_be_bytes());
+        buffer[32] = control.to_primitive();
+        buffer[33] = 0;
+        buffer[34] = 0;
+        buffer[35] = 0;
+        buffer[35] |= self.leap61 as u8;
+        buffer[35] |= (self.leap59 as u8) << 1;
+        buffer[35] |= (self.ptp_boundary_clock as u8) << 2;
+        buffer[35] |= (self.ptp_assist as u8) << 3;
+        buffer[35] |= (self.ptp_ext_sync as u8) << 4;
+        buffer[35] |= (self.parent_stats as u8) << 5;
+        buffer[35] |= (self.ptp_sync_burst as u8) << 6;
+        buffer[36] = 0;
+        buffer[37] = 0;
+        buffer[38] = 0;
+        buffer[39] = 0;
+        Ok(())
+    }
+    pub(crate) fn deserialize_header(buffer: &[u8]) -> Result<DeserializedHeader, WireFormatError> {
+        if buffer.len() < 40 {
+            return Err(WireFormatError::BufferTooShort);
+        }
+        Ok(DeserializedHeader {
+            header: Self {
+                version_ptp: u16::from_be_bytes([buffer[0], buffer[1]]),
+                version_network: u16::from_be_bytes([buffer[2], buffer[3]]),
+                subdomain: buffer[4..20].try_into().unwrap(),
+                source_communication_technology: buffer[21],
+                source_uuid: buffer[22..28].try_into().unwrap(),
+                source_port_id: u16::from_be_bytes([buffer[28], buffer[29]]),
+                sequence_id: u16::from_be_bytes([buffer[30], buffer[31]]),
+                leap61: (buffer[35] & (1 << 0)) > 0,
+                leap59: (buffer[35] & (1 << 1)) > 0,
+                ptp_boundary_clock: (buffer[35] & (1 << 2)) > 0,
+                ptp_assist: (buffer[35] & (1 << 3)) > 0,
+                ptp_ext_sync: (buffer[35] & (1 << 4)) > 0,
+                parent_stats: (buffer[35] & (1 << 5)) > 0,
+                ptp_sync_burst: (buffer[35] & (1 << 6)) > 0
+            },
+            control: buffer[32].try_into()?,
+            //message_length: buffer.len() - 40,
+        })
+    }
+}
+impl Default for Header {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/statime/src/datastructures/messages_v1/mod.rs
+++ b/statime/src/datastructures/messages_v1/mod.rs
@@ -1,0 +1,232 @@
+//! PTPv1 network messages
+pub(crate) use sync_or_delay_req::*;
+pub(crate) use delay_resp::*;
+pub(crate) use follow_up::*;
+pub use header::*;
+use crate::PtpInstanceState;
+
+use super::{common::{PortIdentity, WireTimestampV1}, datasets::{InternalDefaultDS, InternalParentDS}, messages::EnumConversionError, WireFormatError};
+/* use self::{
+    management::ManagementMessage,
+}; */
+/* use super::{
+    WireFormatError,
+};
+use crate::config::ClockIdentity; */
+mod sync_or_delay_req;
+mod control_field;
+use control_field::ControlField;
+mod delay_resp;
+mod follow_up;
+mod header;
+
+/// Maximum length of a packet
+///
+/// This can be used to preallocate buffers that can always fit packets send by
+/// `statime`.
+pub const MAX_DATA_LEN: usize = 255;
+
+
+/// Checks whether message is PTPv1
+pub fn is_compatible(buffer: &[u8]) -> bool {
+    // this ensures that versionPTP in the header is 1
+    (buffer.len() >= 2) && (buffer[0] == 0) && (buffer[1] == 1)
+}
+
+
+/// Type of message, used to differentiate low-delay and other messages.
+/// `Event` is low-delay.
+/// 
+/// To avoid confusion with PTPv2 MessageType which is functionally equivalent
+/// to ControlField in PTPv1, PTPv1's messageType is called here PortType
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u8)]
+pub enum PortType {
+    Event = 0x1,
+    General = 0x2,
+}
+impl TryFrom<u8> for PortType {
+    type Error = EnumConversionError;
+    fn try_from(value: u8) -> Result<Self, Self::Error> {
+        use PortType::*;
+        match value {
+            0x1 => Ok(Event),
+            0x2 => Ok(General),
+            _ => Err(EnumConversionError),
+        }
+    }
+}
+
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct Message {
+    pub(crate) header: Header,
+    pub(crate) body: MessageBody,
+}
+
+impl Message {
+    pub(crate) fn is_event(&self) -> bool {
+        use MessageBody::*;
+        match self.body {
+            Sync(_) | DelayReq(_) => true,
+            FollowUp(_) | DelayResp(_) /* | Management(_) */ => false,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum MessageBody {
+    Sync(SyncMessage),
+    DelayReq(DelayReqMessage),
+    FollowUp(FollowUpMessage),
+    DelayResp(DelayRespMessage),
+    //Management(ManagementMessage), // TODO
+}
+impl MessageBody {
+    fn wire_size(&self) -> usize {
+        match &self {
+            MessageBody::Sync(m) => m.content_size(),
+            MessageBody::DelayReq(m) => m.content_size(),
+            MessageBody::FollowUp(m) => m.content_size(),
+            MessageBody::DelayResp(m) => m.content_size(),
+            /* MessageBody::Management(m) => m.content_size(), */
+        }
+    }
+    fn content_type(&self) -> ControlField {
+        match self {
+            MessageBody::Sync(_) => ControlField::Sync,
+            MessageBody::DelayReq(_) => ControlField::DelayReq,
+            MessageBody::FollowUp(_) => ControlField::FollowUp,
+            MessageBody::DelayResp(_) => ControlField::DelayResp,
+            /* MessageBody::Management(_) => MessageType::Management, */
+        }
+    }
+    pub(crate) fn serialize(&self, buffer: &mut [u8]) -> Result<usize, super::WireFormatError> {
+        match &self {
+            MessageBody::Sync(m) => m.serialize_content(buffer)?,
+            MessageBody::DelayReq(m) => m.serialize_content(buffer)?,
+            MessageBody::FollowUp(m) => m.serialize_content(buffer)?,
+            MessageBody::DelayResp(m) => m.serialize_content(buffer)?,
+            /* MessageBody::Management(m) => m.serialize_content(buffer)?, */
+        }
+        Ok(self.wire_size())
+    }
+    pub(crate) fn deserialize(
+        message_type: ControlField,
+        header: &Header,
+        buffer: &[u8],
+    ) -> Result<Self, super::WireFormatError> {
+        let body = match message_type {
+            ControlField::Sync => MessageBody::Sync(SyncMessage::deserialize_content(*header, buffer)?),
+            ControlField::DelayReq => {
+                MessageBody::DelayReq(DelayReqMessage::deserialize_content(*header, buffer)?)
+            }
+            ControlField::FollowUp => {
+                MessageBody::FollowUp(FollowUpMessage::deserialize_content(buffer)?)
+            }
+            ControlField::DelayResp => {
+                MessageBody::DelayResp(DelayRespMessage::deserialize_content(buffer)?)
+            }
+            /* ControlField::Management => {
+                MessageBody::Management(ManagementMessage::deserialize_content(buffer)?)
+            } */
+        };
+        Ok(body)
+    }
+}
+
+fn base_header(
+    _default_ds: &InternalDefaultDS,
+    port_identity: PortIdentity,
+    sequence_id: u16,
+) -> Header {
+    Header {
+        source_uuid: port_identity.clock_identity.0[0..6].try_into().unwrap(),
+        source_port_id: port_identity.port_number,
+        sequence_id,
+        ..Default::default()
+    }
+}
+
+impl Message {
+    pub(crate) fn header(&self) -> &Header {
+        &self.header
+    }
+    /// The byte size on the wire of this message
+    pub(crate) fn wire_size(&self) -> usize {
+        self.header.wire_size() + self.body.wire_size()
+    }
+    /// Serializes the object into the PTP wire format.
+    ///
+    /// Returns the used buffer size that contains the message or an error.
+    pub(crate) fn serialize(&self, buffer: &mut [u8]) -> Result<usize, super::WireFormatError> {
+        let (header, rest) = buffer.split_at_mut(40);
+        let (body, _tlv) = rest.split_at_mut(self.body.wire_size());
+        self.header
+            .serialize_header(
+                self.body.content_type(),
+                self.body.wire_size(),
+                header,
+            )
+            .unwrap();
+        self.body.serialize(body).unwrap();
+        Ok(self.wire_size())
+    }
+    /// Deserializes a message from the PTP wire format.
+    ///
+    /// Returns the message or an error.
+    pub(crate) fn deserialize(buffer: &[u8]) -> Result<Self, super::WireFormatError> {
+        let header_data = Header::deserialize_header(buffer)?;
+        /* if header_data.message_length < 34 {
+            return Err(WireFormatError::Invalid);
+        } */
+        // Ensure we have the entire message and ignore potential padding
+        // Skip the header bytes and only keep the content
+        let content_buffer = buffer
+            .get(40..buffer.len())
+            .ok_or(WireFormatError::BufferTooShort)?;
+        let body = MessageBody::deserialize(
+            header_data.control,
+            &header_data.header,
+            content_buffer,
+        )?;
+        Ok(Message {
+            header: header_data.header,
+            body,
+        })
+    }
+
+    pub(crate) fn delay_req(
+        global: &PtpInstanceState,
+        port_identity: PortIdentity,
+        sequence_id: u16,
+    ) -> Self {
+        let header = Header {
+            ..base_header(&global.default_ds, port_identity, sequence_id)
+        };
+
+        Message {
+            header,
+            body: MessageBody::DelayReq(DelayReqMessage {
+                header,
+                origin_timestamp: WireTimestampV1::default(),
+                epoch_number: 0, // FIXME
+                current_utc_offset: global.time_properties_ds.current_utc_offset.unwrap_or(0),
+                // FIXME: what if grandmaster is acquired via PTPv2?
+                grandmaster: global.parent_ds.grandmaster_v1.expect("parent_ds.grandmaster_v1 not filled but trying to send DelayReq"),
+                sync_interval: 0x7f,
+                // TODO really? looks like Dante does it this way but is it correct?
+                local_clock_variance: global.default_ds.clock_quality.offset_scaled_log_variance as i16,
+                local_steps_removed: global.current_ds.steps_removed,
+                local_clock_stratum: 255, // TODO but enough for slave-only
+                local_clock_identifier: *b"DFLT", // FIXME
+                parent_communication_technology: 1,
+                parent_uuid: global.parent_ds.parent_port_identity.clock_identity.0[0..6].try_into().unwrap(),
+                parent_port_field: global.parent_ds.parent_port_identity.port_number,
+                estimated_master_variance: 0,
+                estimated_master_drift: 0,
+                utc_reasonable: global.time_properties_ds.current_utc_offset.is_some(),
+            }),
+        }
+    }
+}

--- a/statime/src/datastructures/messages_v1/sync_or_delay_req.rs
+++ b/statime/src/datastructures/messages_v1/sync_or_delay_req.rs
@@ -1,0 +1,97 @@
+use crate::{config::{LeapIndicator, TimePropertiesDS}, datastructures::{common::{GrandmasterPropertiesV1, WireTimestampV1}, WireFormat, WireFormatError}};
+
+use super::Header;
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct SyncOrDelayReqMessage {
+    pub(crate) header: Header,
+    pub(crate) origin_timestamp: WireTimestampV1,
+    pub(crate) epoch_number: u16,
+    pub(crate) current_utc_offset: i16,
+    pub(crate) grandmaster: GrandmasterPropertiesV1,
+    pub(crate) sync_interval: i8,
+    pub(crate) local_clock_variance: i16,
+    pub(crate) local_steps_removed: u16,
+    pub(crate) local_clock_stratum: u8,
+    pub(crate) local_clock_identifier: [u8; 4],
+    pub(crate) parent_communication_technology: u8,
+    pub(crate) parent_uuid: [u8; 6],
+    pub(crate) parent_port_field: u16,
+    pub(crate) estimated_master_variance: i16,
+    pub(crate) estimated_master_drift: i32,
+    pub(crate) utc_reasonable: bool
+}
+impl SyncOrDelayReqMessage {
+    pub(crate) fn content_size(&self) -> usize {
+        84
+    }
+    pub(crate) fn serialize_content(&self, buffer: &mut [u8]) -> Result<(), WireFormatError> {
+        buffer[0..84].fill(0);
+        self.origin_timestamp.serialize(&mut buffer[0..8])?;
+        buffer[8..10].copy_from_slice(&self.epoch_number.to_be_bytes());
+        buffer[10..12].copy_from_slice(&self.current_utc_offset.to_be_bytes());
+        self.grandmaster.serialize(&mut buffer[12..40])?;
+        buffer[43] = self.sync_interval as u8;
+        buffer[46..48].copy_from_slice(&self.local_clock_variance.to_be_bytes());
+        buffer[50..52].copy_from_slice(&self.local_steps_removed.to_be_bytes());
+        buffer[55] = self.local_clock_stratum;
+        buffer[56..60].copy_from_slice(&self.local_clock_identifier);
+        buffer[61] = self.parent_communication_technology;
+        buffer[62..68].copy_from_slice(&self.parent_uuid);
+        buffer[70..72].copy_from_slice(&self.parent_port_field.to_be_bytes());
+        buffer[74..76].copy_from_slice(&self.estimated_master_variance.to_be_bytes());
+        buffer[76..80].copy_from_slice(&self.estimated_master_drift.to_be_bytes());
+        buffer[83] = self.utc_reasonable as u8;
+        Ok(())
+    }
+    pub(crate) fn deserialize_content(header: Header, buffer: &[u8]) -> Result<Self, WireFormatError> {
+        match buffer.get(0..84) {
+            None => {
+                log::error!("BufferTooShort SyncOrDelayReqMessage");
+                Err(WireFormatError::BufferTooShort)
+            },
+            Some(buf) => Ok(Self {
+                header,
+                origin_timestamp: WireTimestampV1::deserialize(&buf[0..8])?,
+                epoch_number: u16::from_be_bytes([buf[8], buf[9]]),
+                current_utc_offset: i16::from_be_bytes([buf[10], buf[11]]),
+                grandmaster: GrandmasterPropertiesV1::deserialize(&buf[12..40])?,
+                sync_interval: buf[43] as i8,
+                local_clock_variance: i16::from_be_bytes([buf[46], buf[47]]),
+                local_steps_removed: u16::from_be_bytes([buf[50], buf[51]]),
+                local_clock_stratum: buf[55],
+                local_clock_identifier: buf[56..60].try_into().unwrap(),
+                parent_communication_technology: buf[61],
+                parent_uuid: buf[62..68].try_into().unwrap(),
+                parent_port_field: u16::from_be_bytes([buf[70], buf[71]]),
+                estimated_master_variance: i16::from_be_bytes([buf[74], buf[75]]),
+                estimated_master_drift: i32::from_be_bytes(buf[76..80].try_into().unwrap()),
+                utc_reasonable: buf[83] > 0
+            }),
+        }
+    }
+
+    pub(crate) fn time_properties(&self) -> TimePropertiesDS {
+        let leap_indicator = if self.header.leap59 {
+            LeapIndicator::Leap59
+        } else if self.header.leap61 {
+            LeapIndicator::Leap61
+        } else {
+            LeapIndicator::NoLeap
+        };
+
+        let current_utc_offset = self
+            .utc_reasonable
+            .then_some(self.current_utc_offset);
+
+        TimePropertiesDS {
+            current_utc_offset,
+            leap_indicator,
+            time_traceable: false, // TODO
+            frequency_traceable: false, // TODO
+            ptp_timescale: [*b"ATOM", *b"GPS\0", *b"NTP\0", *b"HAND"].contains(&self.grandmaster.clock_identifier), // TODO: really???
+            time_source: crate::config::TimeSource::InternalOscillator, // TODO
+        }
+    }
+}
+pub(crate) type SyncMessage = SyncOrDelayReqMessage;
+pub(crate) type DelayReqMessage = SyncOrDelayReqMessage;

--- a/statime/src/datastructures/mod.rs
+++ b/statime/src/datastructures/mod.rs
@@ -7,6 +7,14 @@ use self::messages::EnumConversionError;
 pub mod common;
 pub mod datasets;
 pub mod messages;
+pub mod messages_v1;
+
+/// Universal Message container supporting multiple PTP versions
+pub enum MessageV<'a> {
+    PTPv1(messages_v1::Message),
+    PTPv2(messages::Message<'a>),
+}
+
 
 #[derive(Clone, Debug)]
 pub(crate) enum WireFormatError {
@@ -54,3 +62,5 @@ trait WireFormat: Debug + Clone + Eq {
     /// error.
     fn deserialize(buffer: &[u8]) -> Result<Self, WireFormatError>;
 }
+
+

--- a/statime/src/time/instant.rs
+++ b/statime/src/time/instant.rs
@@ -11,7 +11,7 @@ use fixed::{
 };
 
 use super::duration::Duration;
-use crate::datastructures::common::WireTimestamp;
+use crate::datastructures::common::{WireTimestamp, WireTimestampV1};
 
 /// Time represents a specific moment in time.
 ///
@@ -93,6 +93,12 @@ impl Time {
 
 impl From<WireTimestamp> for Time {
     fn from(ts: WireTimestamp) -> Self {
+        Self::from_fixed_nanos(ts.seconds as i128 * 1_000_000_000i128 + ts.nanos as i128)
+    }
+}
+
+impl From<WireTimestampV1> for Time {
+    fn from(ts: WireTimestampV1) -> Self {
         Self::from_fixed_nanos(ts.seconds as i128 * 1_000_000_000i128 + ts.nanos as i128)
     }
 }


### PR DESCRIPTION
Working on #382 

Slave-only for now.

I've implemented PTPv1-related functions side-by-side in the same `impl` blocks that PTPv2 implementation. Some logic was adjusted to the IEEE1588-2002 specification, some was reused or copied without logical changes, so probably not yet standard-compliant. But it works as a slave in Dante network.

Putting it here early because I want your opinion on this approach, or maybe you have a better idea of code organization?

### To do:
* operation as master
* fix code repetitions (generalization is possible in some places marked with `TODO DRY`)
* fill fields in packets and data structures with meaningful values instead of placeholders: in PTPv1 packets: `local_clock_stratum`, `local_clock_identifier`, `epoch_numer`, in PtpInstanceState: `clock_class`, `clock_accuracy`
   * I will try to understand differences between specifications and possibility of interconnecting PTPv1 and v2 networks, however, help with this will be appreciated.
* write tests specifically for PTPv1, resurrect commented out tests
* remove unused code & cargo fmt

I've put the following remark in a comment:

> It is technically possible to run different versions of PTP on the same physical Ethernet interface (Dante devices do this when having AES67 enabled) - this way PTPv1-to-v2 or vice versa "converter" can be created. To do this in Statime, create multiple Port instances, route packets to `handle_*_receive` methods according to PTP version in packet's header and merge actions from `PortActionIterator`s. Not tested yet, beware of possible strange conditions like boundary clock loops.

But it is requiring library user to do something that could be already implemented in Statime. But implementing it in the library would require a refactor, adding an intermediate layer because we want one physical port to correspond to multiple IEEE1588 ports so that PTPv1 slave clock can be PTPv2 master or vice versa (inter-version boundary clock, Dante devices do this)

### How to run:
add

`protocol-version = "PTPv1"`

to port config