### PR TITLE
Fix `/metrics` page displays `true`, `false` instead of `0`, `1`

### DIFF
--- a/statime-linux/src/metrics/format.rs
+++ b/statime-linux/src/metrics/format.rs
@@ -310,12 +310,12 @@ fn format_path_trace_ds(
     format_metric(
         w,
         "path_trace_enable",
-        "true if path trace options is enabled",
+        "1 if path trace options is enabled, 0 otherwise",
         MetricType::Gauge,
         None,
         vec![Measurement {
             labels: labels.clone(),
-            value: path_trace_ds.enable,
+            value: format_bool!(path_trace_ds.enable),
         }],
     )?;
 


### PR DESCRIPTION
According to the OpenMetrics specification, boolean values [must be encoded](https://github.com/prometheus/OpenMetrics/blob/main/specification/OpenMetrics.md#values) as 0 and 1.
I encontered this bug while using Prometheus to scrape the metrics, which produced the following error line and resulted in no values being reported for any metric.

```
ts=2025-02-21T09:55:03.007Z caller=scrape.go:1307 level=debug component="scrape manager" scrape_pool=local_ptp target=http://localhost:1337/metrics msg="Append failed" err="strconv.ParseFloat: parsing \"false\": invalid syntax"
```