### PR TITLE
Fix wrong metric description (copy-past from previous)

### DIFF
--- a/statime-linux/src/metrics/format.rs
+++ b/statime-linux/src/metrics/format.rs
@@ -290,7 +290,7 @@ pub fn format_time_properties_ds(
     format_metric(
         w,
         "time_source",
-        "Wheter the timescale of the Grandmaster PTP Instance is PTP",
+        "The source of time used by the Grandmaster PTP instance",
         MetricType::Gauge,
         None,
         vec![Measurement {


### PR DESCRIPTION
Apparently, the description of `time_source` as been copied from `ptp_timescale`, the metric one above. I tried to come up with a meaningful description based on Section 8.2.4.9 of the IEEE Std 1588-2019. Feel free to adopt it if necessary.