### PR TITLE
Add clock quality to instance config

### DIFF
--- a/statime-linux/src/main.rs
+++ b/statime-linux/src/main.rs
@@ -9,7 +9,7 @@ use std::{
 use clap::Parser;
 use rand::{rngs::StdRng, SeedableRng};
 use statime::{
-    config::{ClockIdentity, InstanceConfig, SdoId, TimePropertiesDS, TimeSource},
+    config::{ClockIdentity, ClockQuality, InstanceConfig, SdoId, TimePropertiesDS, TimeSource},
     filters::{Filter, KalmanConfiguration, KalmanFilter},
     port::{
         is_message_buffer_compatible, InBmca, Measurement, Port, PortAction, PortActionIterator,
@@ -272,6 +272,7 @@ async fn actual_main() {
         slave_only: config.slave_only,
         sdo_id: SdoId::try_from(config.sdo_id).expect("sdo-id should be between 0 and 4095"),
         path_trace: config.path_trace,
+        clock_quality: ClockQuality::default(),
     };
 
     let time_properties_ds =

--- a/statime-stm32/src/port.rs
+++ b/statime-stm32/src/port.rs
@@ -9,7 +9,7 @@ use smoltcp::{
 use static_cell::StaticCell;
 use statime::{
     config::{
-        AcceptAnyMaster, ClockIdentity, DelayMechanism, InstanceConfig, PortConfig,
+        AcceptAnyMaster, ClockIdentity, ClockQuality, DelayMechanism, InstanceConfig, PortConfig,
         PtpMinorVersion, SdoId, TimePropertiesDS, TimeSource,
     },
     filters::BasicFilter,
@@ -287,6 +287,7 @@ pub fn setup_statime(
         slave_only: false,
         sdo_id: SdoId::default(),
         path_trace: false,
+        clock_quality: ClockQuality::default(),
     };
     let time_properties_ds =
         TimePropertiesDS::new_arbitrary_time(false, false, TimeSource::InternalOscillator);

--- a/statime/src/bmc/bmca.rs
+++ b/statime/src/bmc/bmca.rs
@@ -300,7 +300,7 @@ mod tests {
     use super::*;
     use crate::{
         bmc::acceptable_master::AcceptAnyMaster,
-        config::{ClockIdentity, InstanceConfig},
+        config::{ClockIdentity, ClockQuality, InstanceConfig},
         datastructures::messages::{Header, PtpVersion},
     };
 
@@ -505,6 +505,7 @@ mod tests {
             slave_only,
             sdo_id,
             path_trace,
+            clock_quality: ClockQuality::default(),
         })
     }
 
@@ -539,8 +540,11 @@ mod tests {
         let slave_only = false;
         let sdo_id = Default::default();
         let path_trace = false;
+        let mut clock_quality = ClockQuality::default();
+        clock_quality.clock_class = 1;
+        assert!((1..=127).contains(&clock_quality.clock_class));
 
-        let mut own_data = InternalDefaultDS::new(InstanceConfig {
+        let own_data = InternalDefaultDS::new(InstanceConfig {
             clock_identity,
             priority_1,
             priority_2,
@@ -548,10 +552,8 @@ mod tests {
             slave_only,
             sdo_id,
             path_trace,
+            clock_quality,
         });
-
-        own_data.clock_quality.clock_class = 1;
-        assert!((1..=127).contains(&own_data.clock_quality.clock_class));
 
         // D0 is the same as E_rbest; this is unreachable in practice, but we return M1
         // in this case

--- a/statime/src/config/instance.rs
+++ b/statime/src/config/instance.rs
@@ -1,4 +1,4 @@
-use crate::config::{ClockIdentity, SdoId};
+use crate::config::{ClockIdentity, ClockQuality, SdoId};
 #[cfg(doc)]
 use crate::PtpInstance;
 
@@ -7,7 +7,7 @@ use crate::PtpInstance;
 /// # Example
 /// A configuration with common default values:
 /// ```
-/// # use statime::config::{ClockIdentity, InstanceConfig, SdoId};
+/// # use statime::config::{ClockIdentity, InstanceConfig, SdoId, ClockQuality};
 /// let config = InstanceConfig {
 ///     clock_identity: ClockIdentity::from_mac_address([1,2,3,4,5,6]),
 ///     priority_1: 128,
@@ -16,6 +16,7 @@ use crate::PtpInstance;
 ///     sdo_id: SdoId::default(),
 ///     slave_only: false,
 ///     path_trace: false,
+///     clock_quality: ClockQuality::default(),
 /// };
 /// ```
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
@@ -49,4 +50,7 @@ pub struct InstanceConfig {
 
     /// Whether the path trace option is enabled
     pub path_trace: bool,
+
+    /// A description of the accuracy and type of the local clock.
+    pub clock_quality: ClockQuality,
 }

--- a/statime/src/datastructures/common/clock_accuracy.rs
+++ b/statime/src/datastructures/common/clock_accuracy.rs
@@ -1,6 +1,6 @@
 use core::cmp::Ordering;
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 /// How accurate the underlying clock device is expected to be when not
 /// synchronized.

--- a/statime/src/datastructures/common/clock_quality.rs
+++ b/statime/src/datastructures/common/clock_quality.rs
@@ -2,7 +2,7 @@ use super::clock_accuracy::ClockAccuracy;
 use crate::datastructures::{WireFormat, WireFormatError};
 
 /// A description of the accuracy and type of a clock.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ClockQuality {
     /// The PTP clock class.

--- a/statime/src/datastructures/datasets/default.rs
+++ b/statime/src/datastructures/datasets/default.rs
@@ -30,7 +30,7 @@ impl InternalDefaultDS {
         Self {
             clock_identity: config.clock_identity,
             number_ports: 0,
-            clock_quality: Default::default(),
+            clock_quality: config.clock_quality,
             priority_1: config.priority_1,
             priority_2: config.priority_2,
             domain_number: config.domain_number,

--- a/statime/src/port/bmca.rs
+++ b/statime/src/port/bmca.rs
@@ -292,7 +292,7 @@ impl<A, C: Clock, F: Filter, R: Rng, S: PtpInstanceStateMutex> Port<'_, InBmca, 
 mod tests {
     use super::*;
     use crate::{
-        config::{ClockIdentity, InstanceConfig, SdoId},
+        config::{ClockIdentity, ClockQuality, InstanceConfig, SdoId},
         datastructures::{
             common::{PortIdentity, Tlv, TlvSetBuilder},
             messages::{AnnounceMessage, Header, Message, MessageBody, PtpVersion, MAX_DATA_LEN},
@@ -402,6 +402,7 @@ mod tests {
             sdo_id: SdoId::default(),
             slave_only: false,
             path_trace: false,
+            clock_quality: ClockQuality::default(),
         };
         let mut port = port.start_bmca();
         port.set_recommended_port_state(

--- a/statime/src/port/mod.rs
+++ b/statime/src/port/mod.rs
@@ -712,7 +712,8 @@ mod tests {
     use super::*;
     use crate::{
         config::{
-            AcceptAnyMaster, DelayMechanism, InstanceConfig, PtpMinorVersion, TimePropertiesDS,
+            AcceptAnyMaster, ClockQuality, DelayMechanism, InstanceConfig, PtpMinorVersion,
+            TimePropertiesDS,
         },
         datastructures::datasets::{InternalDefaultDS, InternalParentDS, PathTraceDS},
         filters::BasicFilter,
@@ -838,6 +839,7 @@ mod tests {
             slave_only: false,
             sdo_id: Default::default(),
             path_trace: false,
+            clock_quality: ClockQuality::default(),
         });
 
         let parent_ds = InternalParentDS::new(default_ds);

--- a/statime/src/ptp_instance.rs
+++ b/statime/src/ptp_instance.rs
@@ -58,7 +58,7 @@ use crate::{
 /// # let rng: rand::rngs::mock::StepRng = unimplemented!();
 /// #
 /// use statime::PtpInstance;
-/// use statime::config::{AcceptAnyMaster, ClockIdentity, InstanceConfig, TimePropertiesDS, TimeSource};
+/// use statime::config::{AcceptAnyMaster, ClockIdentity, ClockQuality, InstanceConfig, TimePropertiesDS, TimeSource};
 /// use statime::filters::BasicFilter;
 ///
 /// let instance_config = InstanceConfig {
@@ -69,6 +69,7 @@ use crate::{
 ///     slave_only: false,
 ///     sdo_id: Default::default(),
 ///     path_trace: false,
+///     clock_quality: ClockQuality::default(),
 /// };
 /// let time_properties_ds = TimePropertiesDS::new_arbitrary_time(false, false, TimeSource::InternalOscillator);
 ///


### PR DESCRIPTION
A default clock quality configuration is currently used, without the ability to configure it.
This PR adds clock quality to the `InstanceConfig` struct so users can configure the clock quality if they desire. If not, `ClockQuality::default()` can be used.

Resolves #677, with a potential follow-up PR to allow the clock quality to be changed on the fly.