### PR TITLE
Fix unsound rand rustsec 2026 0097

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -166,13 +166,14 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.17"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi",
+ "r-efi",
+ "wasip2",
 ]
 
 [[package]]
@@ -322,21 +323,26 @@ dependencies = [
 ]
 
 [[package]]
-name = "rand"
-version = "0.8.6"
+name = "r-efi"
+version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "rand"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
- "libc",
  "rand_chacha",
  "rand_core",
 ]
 
 [[package]]
 name = "rand_chacha"
-version = "0.3.1"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
  "rand_core",
@@ -344,9 +350,9 @@ dependencies = [
 
 [[package]]
 name = "rand_core"
-version = "0.6.4"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
  "getrandom",
 ]
@@ -660,6 +666,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
+name = "wasip2"
+version = "1.0.3+wasi-0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
+dependencies = [
+ "wit-bindgen",
+]
+
+[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -682,6 +697,12 @@ checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
 name = "zerocopy"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ log = { version = "0.4.27", default-features = false }
 pin-project-lite = "0.2.13"
 toml = ">=0.5.0, <0.9.0"
 tokio = "1.33"
-rand = { version = "0.8.5", default-features = false }
+rand = { version = "0.9.4", default-features = false }
 serde = { version = "1.0.192", features = ["derive"] }
 serde_json = { version = "1.0.111" }
 serde_test = { version = "1.0.176" }

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -172,18 +172,18 @@ checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "rand"
-version = "0.8.6"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
  "rand_core",
 ]
 
 [[package]]
 name = "rand_core"
-version = "0.6.4"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 
 [[package]]
 name = "serde"

--- a/statime-linux/Cargo.toml
+++ b/statime-linux/Cargo.toml
@@ -33,7 +33,7 @@ log = { workspace = true, default-features = true }
 pin-project-lite.workspace = true
 toml.workspace = true
 tokio = { workspace = true, features = ["net", "rt-multi-thread", "time", "macros", "sync", "io-util"] }
-rand = { workspace = true, default-features = false, features = ["std", "std_rng"] }
+rand = { workspace = true, default-features = false, features = ["std", "std_rng", "os_rng"] }
 serde.workspace = true
 serde_json.workspace = true
 

--- a/statime-linux/src/main.rs
+++ b/statime-linux/src/main.rs
@@ -368,7 +368,7 @@ async fn actual_main() {
             HardwareClock::None => add_sw_clock(&mut clock_port_map),
         };
 
-        let rng = StdRng::from_entropy();
+        let rng = StdRng::from_os_rng();
         let port = instance.add_port(
             port_config.into(),
             KalmanConfiguration::default(),

--- a/statime-stm32/Cargo.lock
+++ b/statime-stm32/Cargo.lock
@@ -716,11 +716,11 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.8.6"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
- "rand_core",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -728,6 +728,12 @@ name = "rand_core"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 
 [[package]]
 name = "regex-automata"
@@ -1041,7 +1047,7 @@ dependencies = [
  "fugit-timer",
  "micromath",
  "nb 1.1.0",
- "rand_core",
+ "rand_core 0.6.4",
  "stm32-fmc",
  "stm32f7",
  "time",

--- a/statime/src/config/port.rs
+++ b/statime/src/config/port.rs
@@ -102,7 +102,7 @@ impl<A> PortConfig<A> {
     /// For more information see *IEEE1588-2019 section 9.2.6.12*
     pub fn announce_duration(&self, rng: &mut impl Rng) -> core::time::Duration {
         // add some randomness so that not all timers expire at the same time
-        let factor = 1.0 + rng.sample::<f64, _>(rand::distributions::Open01);
+        let factor = 1.0 + rng.sample::<f64, _>(rand::distr::Open01);
         let duration = self.announce_interval.as_core_duration();
 
         duration.mul_f64(factor * self.announce_receipt_timeout as u32 as f64)

--- a/statime/src/port/mod.rs
+++ b/statime/src/port/mod.rs
@@ -118,7 +118,6 @@ pub(crate) mod state;
 /// #     }
 /// # }
 /// # let (instance_config, time_properties_ds) = unimplemented!();
-/// use rand::thread_rng;
 /// use statime::config::{AcceptAnyMaster, DelayMechanism, PortConfig, PtpMinorVersion};
 /// use statime::filters::BasicFilter;
 /// use statime::PtpInstance;
@@ -140,7 +139,8 @@ pub(crate) mod state;
 /// };
 /// let filter_config = 1.0;
 /// let clock = system::Clock {};
-/// let rng = thread_rng();
+/// # #[allow(deprecated)]
+/// let rng = rand::rngs::mock::StepRng::new(2, 1);
 ///
 /// let port_in_bmca = instance.add_port(port_config, filter_config, clock, rng);
 ///

--- a/statime/src/port/mod.rs
+++ b/statime/src/port/mod.rs
@@ -139,8 +139,13 @@ pub(crate) mod state;
 /// };
 /// let filter_config = 1.0;
 /// let clock = system::Clock {};
-/// # #[allow(deprecated)]
-/// let rng = rand::rngs::mock::StepRng::new(2, 1);
+/// # struct MockRng(u64);
+/// # impl rand::RngCore for MockRng {
+/// #     fn next_u32(&mut self) -> u32 { self.next_u64() as u32 }
+/// #     fn next_u64(&mut self) -> u64 { self.0 = self.0.wrapping_add(1); self.0 }
+/// #     fn fill_bytes(&mut self, dest: &mut [u8]) { for chunk in dest.chunks_mut(8) { let b = self.next_u64().to_le_bytes(); chunk.copy_from_slice(&b[..chunk.len()]); } }
+/// # }
+/// let rng = MockRng(0);
 ///
 /// let port_in_bmca = instance.add_port(port_config, filter_config, clock, rng);
 ///
@@ -722,6 +727,24 @@ mod tests {
     };
 
     // General test infra
+    pub(super) struct MockRng(u64);
+
+    impl rand::RngCore for MockRng {
+        fn next_u32(&mut self) -> u32 {
+            self.next_u64() as u32
+        }
+        fn next_u64(&mut self) -> u64 {
+            self.0 = self.0.wrapping_add(1);
+            self.0
+        }
+        fn fill_bytes(&mut self, dest: &mut [u8]) {
+            for chunk in dest.chunks_mut(8) {
+                let bytes = self.next_u64().to_le_bytes();
+                chunk.copy_from_slice(&bytes[..chunk.len()]);
+            }
+        }
+    }
+
     pub(super) struct TestClock;
 
     impl Clock for TestClock {
@@ -749,7 +772,7 @@ mod tests {
 
     pub(super) fn setup_test_port(
         state: &RefCell<PtpInstanceState>,
-    ) -> Port<'_, Running, AcceptAnyMaster, rand::rngs::mock::StepRng, TestClock, BasicFilter> {
+    ) -> Port<'_, Running, AcceptAnyMaster, MockRng, TestClock, BasicFilter> {
         let port = Port::<_, _, _, _, BasicFilter>::new(
             state,
             PortConfig {
@@ -767,7 +790,7 @@ mod tests {
             0.25,
             TestClock,
             Default::default(),
-            rand::rngs::mock::StepRng::new(2, 1),
+            MockRng(0),
         );
 
         let (port, _) = port.end_bmca();
@@ -777,7 +800,7 @@ mod tests {
     pub(super) fn setup_test_port_custom_identity(
         state: &RefCell<PtpInstanceState>,
         port_identity: PortIdentity,
-    ) -> Port<'_, Running, AcceptAnyMaster, rand::rngs::mock::StepRng, TestClock, BasicFilter> {
+    ) -> Port<'_, Running, AcceptAnyMaster, MockRng, TestClock, BasicFilter> {
         let port = Port::<_, _, _, _, BasicFilter>::new(
             state,
             PortConfig {
@@ -795,7 +818,7 @@ mod tests {
             0.25,
             TestClock,
             port_identity,
-            rand::rngs::mock::StepRng::new(2, 1),
+            MockRng(0),
         );
 
         let (port, _) = port.end_bmca();
@@ -805,7 +828,7 @@ mod tests {
     pub(super) fn setup_test_port_custom_filter<F: Filter>(
         state: &RefCell<PtpInstanceState>,
         filter_config: F::Config,
-    ) -> Port<'_, Running, AcceptAnyMaster, rand::rngs::mock::StepRng, TestClock, F> {
+    ) -> Port<'_, Running, AcceptAnyMaster, MockRng, TestClock, F> {
         let port = Port::<_, _, _, _, F>::new(
             state,
             PortConfig {
@@ -823,7 +846,7 @@ mod tests {
             filter_config,
             TestClock,
             Default::default(),
-            rand::rngs::mock::StepRng::new(2, 1),
+            MockRng(0),
         );
 
         let (port, _) = port.end_bmca();

--- a/statime/src/port/slave.rs
+++ b/statime/src/port/slave.rs
@@ -495,7 +495,7 @@ impl<A, C: Clock, F: Filter, R: Rng, S: PtpInstanceStateMutex> Port<'_, Running,
             response_recv_time: None,
         };
 
-        let random = self.rng.sample::<f64, _>(rand::distributions::Open01);
+        let random = self.rng.sample::<f64, _>(rand::distr::Open01);
         let factor = random * 2.0f64;
         let duration = log_min_pdelay_req_interval
             .as_core_duration()
@@ -545,7 +545,7 @@ impl<A, C: Clock, F: Filter, R: Rng, S: PtpInstanceStateMutex> Port<'_, Running,
                     recv_time: None,
                 };
 
-                let random = self.rng.sample::<f64, _>(rand::distributions::Open01);
+                let random = self.rng.sample::<f64, _>(rand::distr::Open01);
                 let factor = random * 2.0f64;
                 let duration = log_min_delay_req_interval
                     .as_core_duration()

--- a/statime/src/ptp_instance.rs
+++ b/statime/src/ptp_instance.rs
@@ -55,7 +55,13 @@ use crate::{
 /// # let port_config: statime::config::PortConfig<AcceptAnyMaster> = unimplemented!();
 /// # let filter_config = unimplemented!();
 /// # let clock: MockClock = unimplemented!();
-/// # let rng: rand::rngs::mock::StepRng = unimplemented!();
+/// # struct MockRng(u64);
+/// # impl rand::RngCore for MockRng {
+/// #     fn next_u32(&mut self) -> u32 { self.next_u64() as u32 }
+/// #     fn next_u64(&mut self) -> u64 { self.0 = self.0.wrapping_add(1); self.0 }
+/// #     fn fill_bytes(&mut self, dest: &mut [u8]) { for chunk in dest.chunks_mut(8) { let b = self.next_u64().to_le_bytes(); chunk.copy_from_slice(&b[..chunk.len()]); } }
+/// # }
+/// # let rng: MockRng = unimplemented!();
 /// #
 /// use statime::PtpInstance;
 /// use statime::config::{AcceptAnyMaster, ClockIdentity, ClockQuality, InstanceConfig, TimePropertiesDS, TimeSource};


### PR DESCRIPTION
**Upgrade rand 0.8 → 0.9 (mitigates [RUSTSEC-2026-0097](https://rustsec.org/advisories/RUSTSEC-2026-0097.html))**

  Bumps rand from 0.8.5 to 0.9.4 to resolve the advisory flagged in the previous commit. Adapts all call sites to the breaking API changes in rand 0.9.

  **API changes**

| Old (0.8) | New (0.9) |
  |---|---|
  | `rand::distributions::Open01` | `rand::distr::Open01` |
  | `SeedableRng::from_entropy()` | `SeedableRng::from_os_rng()` |
  | `rand::rngs::mock::StepRng` | local `MockRng` (see below) |

  from_os_rng() requires the os_rng feature in rand_core, exposed as rand's own os_rng feature — added to statime-linux's dependency.

  **MockRng**

  rand::rngs::mock::StepRng was deprecated in 0.9 without replacement. Rather than suppress the warning, a minimal MockRng(u64) implementing RngCore is added to the test module. The RNG is only used to produce timing jitter in delay
  requests, so the specific values don't affect test correctness.

  **Test results**

  74 unit tests + 13 doctests pass with no warnings.
